### PR TITLE
Fix chrome keyboard extension compatibility

### DIFF
--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -33,13 +33,15 @@
     <div class="accordion-heading job-header">
       <div class="queue-row-container" data-bind="visible: queuesets().length > 0">
         <i class="fas fa-grip-lines-vertical"></i>
-        <input type="text" class="job-name" data-bind="textInput: name, event: { change: $root.setJobName }, css: {'bold': $root.isActiveItem($index)()}" placeholder="Click here to name"></input>
+        <!-- _vkenabled fixes dynamic form bug on virtual keyboard: https://github.com/xontab/chrome-virtual-keyboard/issues/5 --> 
+        <input type="text" class="job-name" data-bind="textInput: name, event: { change: $root.setJobName }, attr: {'_vkenabled': false}, css: {'bold': $root.isActiveItem($index)()}" placeholder="Click here to name"></input>
         <div class="progress" data-bind="foreach: progress, css: { 'progress-striped active': $root.isActiveItem($index)() }">
           <div data-bind="style: { flex: pct, order: order }, css: {'active': result === 'started', 'bar': result !== 'pending', 'bar-success': result == 'success', 'bar-danger': result.startsWith('failure')}"></div>
         </div>
         <div class="repeats">
           <span data-bind="text: runs_completed() + ' /'">/</span>
-          <input class="fa fa-text count-box" type="number" data-bind="textInput: count, event: { change: $root.setCount }"></input>
+          <!-- _vkenabled fixes dynamic form bug on virtual keyboard: https://github.com/xontab/chrome-virtual-keyboard/issues/5 --> 
+          <input class="fa fa-text count-box" type="number" data-bind="textInput: count, event: { change: $root.setCount }, attr: {'_vkenabled': false}"></input>
         </div>
         <div class="total" data-bind="text: items_completed() + '/' + length()"></div>
         <div class="accordion-heading-button pull-right" data-bind="click: $root.remove"><i style="cursor: pointer" class="far fa-trash-alt"></i></div>
@@ -62,7 +64,8 @@
                     <div data-bind="style: { flex: pct, order: order }, css: {'bar': result !== 'pending', 'active': result === 'started', 'bar-success': result == 'success', 'bar-danger': result.startsWith('failure')}"></div>
                   </div>
                   <div class="repeats">
-                    <input class="fa fa-text count-box" type="number" data-bind="textInput: count, event: { change: $root.setCount }"></input>
+                    <!-- _vkenabled fixes dynamic form bug on virtual keyboard: https://github.com/xontab/chrome-virtual-keyboard/issues/5 --> 
+                    <input class="fa fa-text count-box" type="number" data-bind="textInput: count, event: { change: $root.setCount }, attr: {'_vkenabled': false}"></input>
                   </div>
                   <div class="total" data-bind="text: items_completed() + '/' + length()"></div>
                   <div class="accordion-heading-button" data-bind="click: $root.remove"><i style="cursor: pointer" class="far fa-trash-alt"></i></div>


### PR DESCRIPTION
For #8 - apparently dynamically added input elements doesn't play nicely with the virtual keyboard extension for chrome, without clearing the `_vkenabled` signal attribute on the element so it properly re-binds event handlers to the clone.

https://github.com/xontab/chrome-virtual-keyboard/issues/5