### PR TITLE
Update settings for failure recovery, add more docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,3 @@ WARNING: Your printer must have a method of clearing the bed automatically, with
 # Documentation
 
 See https://smartin015.github.io/continuousprint/ for all documentation on installation, setup, queueing strategies, and development.
-

--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -83,6 +83,20 @@ class ContinuousprintPlugin(
 
     # part of StartupPlugin
     def on_after_startup(self):
+        # Turn on "restart on pause" when TSD plugin is detected (must be version 1.8.11 or higher for custom event hook)
+        if (
+            getattr(
+                octoprint.events.Events, "PLUGIN_THESPAGHETTIDETECTIVE_COMMAND", None
+            )
+            is not None
+        ):
+            self._logger.info(
+                "Has TSD plugin with custom events integration - enabling failure automation"
+            )
+            self._settings.set([RESTART_ON_PAUSE_KEY], True)
+        else:
+            self._settings.set([RESTART_ON_PAUSE_KEY], False)
+
         self._settings.save()
         self.q = PrintQueue(self._settings, QUEUE_KEY)
         self.d = ContinuousPrintDriver(

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -3,7 +3,7 @@
 <form class="form-horizontal">
   <h3>Basic Scripts</h3>
   <p>
-  For examples and best practices, see the <a href="https://smartin015.github.io/continuousprint/gcode-scripting/" target="_blank">GCODE scripting guide</a>.  
+  For examples and best practices, see the <a href="https://smartin015.github.io/continuousprint/gcode-scripting/" target="_blank">GCODE scripting guide</a>.
   </p>
   <fieldset>
     <div class="control-group">
@@ -22,37 +22,32 @@
 
   <fieldset>
     <h3>Failure Recovery</h3>
-    <div class="alert" data-bind="visible: !settings.plugins.continuousprint.failure_recovery_enabled">
-      <p>Failure recovery requires <a href="https://www.thespaghettidetective.com/" target="_blank">The Spaghetti Detective</a>, but the plugin does not appear to be installed.<p>
+    <div class="alert" data-bind="hidden: settings.plugins.continuousprint.cp_restart_on_pause_enabled">
+      <p>Failure recovery requires <a href="https://www.thespaghettidetective.com/" target="_blank">The Spaghetti Detective</a> version &geq; 1.8.11, but the plugin does not appear to be installed.<p>
       <p>Read more about how to set this up in the <a href="https://smartin015.github.io/continuousprint/failure-recovery/" target="_blank">Failure Recovery guide</a>.</p>
     </div>
-    <div data-bind="visible: settings.plugin.continuousprint.failure_recovery_enabled">
+    <div data-bind="visible: settings.plugins.continuousprint.cp_restart_on_pause_enabled">
+      <p>
+        Failure recovery is enabled because <a href="https://www.thespaghettidetective.com/" target="_blank">The Spaghetti Detective</a> is installed.
+      </p>
       <p>
         Read more about failure recovery settings in the <a href="https://smartin015.github.io/continuousprint/failure-recovery/" target="_blank">Failure Recovery guide</a>.
+      </p>
       <div class="control-group">
-        <label class="control-label">Enable restart on pause</label>
-        <div class="controls">
-          <label class="checkbox">
-            <input type="checkbox" data-bind="checked: settings.plugins.continuousprint.cp_restart_on_pause_enabled"/>
-              Repeat current queued print when state is <code>PAUSED</code>
-          </label>
-        </div>
-      </div>
-      <div class="control-group">
-        <label class="control-label">Do nothing if printing &gt;</label>
+        <label class="control-label">Retry if started less than</label>
         <div class="controls">
           <div class="input-append">
             <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_seconds"/>
-            <span class="add-on">s</span>
+            <span class="add-on">seconds ago</span>
           </div>
         </div>
       </div>
       <div class="control-group">
-        <label class="control-label">Give up after</label>
+        <label class="control-label">Stop the queue after</label>
         <div class="controls">
           <div class="input-append">
             <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_restarts"/>
-            <span class="add-on">restarts</span>
+            <span class="add-on">retries</span>
           </div>
         </div>
       </div>

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -1,56 +1,59 @@
-<h4>Continuous Print Settings</h4>
+<h3>Continuous Print Settings</h3>
+
 <form class="form-horizontal">
-	<p>
-		When continually printing the bed needs to be cleared in order for the next print to work.
-	</p>
-	<p>
-		If your printer requires manual intervention to clear the bed, you can use <a href="https://docs.octoprint.org/en/master/features/atcommands.html" target="_blank">@ Commands</a> such as <code>@pause</code> to tell OctoPrint to pause indefinitely until the resume button is pressed.
-	</p>
-
-	<div class="control-group">
-        <label class="control-label">Bed cleaning script</label>
-        <div class="controls">
-            <textarea rows="8" class="input-block-level" data-bind="value: settings.plugins.continuousprint.cp_bed_clearing_script"></textarea>
-        </div>
+  <h3>Basic Scripts</h3>
+  <p>
+  For examples and best practices, see the <a href="https://smartin015.github.io/continuousprint/gcode-scripting/" target="_blank">GCODE scripting guide</a>.  
+  </p>
+  <fieldset>
+    <div class="control-group">
+      <label class="control-label">Bed cleaning script</label>
+      <div class="controls">
+        <textarea rows="8" class="input-block-level" data-bind="value: settings.plugins.continuousprint.cp_bed_clearing_script"></textarea>
+      </div>
     </div>
-
-	<div class="control-group">
-        <label class="control-label">Queue finished script</label>
-        <div class="controls">
-            <textarea rows="8" class="input-block-level" data-bind="value: settings.plugins.continuousprint.cp_queue_finished_script"></textarea>
-        </div>
+    <div class="control-group">
+      <label class="control-label">Queue finished script</label>
+      <div class="controls">
+      <textarea rows="8" class="input-block-level" data-bind="value: settings.plugins.continuousprint.cp_queue_finished_script"></textarea>
+      </div>
     </div>
+  </fieldset>
 
   <fieldset>
-    <legend>Restart on Pause</legend>
-    <p>
-      Print failure detection automation (such as <a target="_blank" href="https://www.thespaghettidetective.com/">Spaghetti Detective</a>) may auto-pause
-      a print if it detects a potential failure. Enable this feature to auto-retry the current queued print when Octoprint moves to a <code>PAUSED</code> state.
-    </p>
-    <div class="control-group">
-      <label class="control-label">Enable restart on pause</label>
-      <div class="controls">
-        <label class="checkbox">
-          <input type="checkbox" data-bind="checked: settings.plugins.continuousprint.cp_restart_on_pause_enabled"/>
-            Repeat current queued print when state is <code>PAUSED</code>
-        </label>
-      </div>
+    <h3>Failure Recovery</h3>
+    <div class="alert" data-bind="visible: !settings.plugins.continuousprint.failure_recovery_enabled">
+      <p>Failure recovery requires <a href="https://www.thespaghettidetective.com/" target="_blank">The Spaghetti Detective</a>, but the plugin does not appear to be installed.<p>
+      <p>Read more about how to set this up in the <a href="https://smartin015.github.io/continuousprint/failure-recovery/" target="_blank">Failure Recovery guide</a>.</p>
     </div>
-    <div class="control-group">
-      <label class="control-label">Do nothing if printing &gt;</label>
-      <div class="controls">
-        <div class="input-append">
-          <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_seconds"/>
-          <span class="add-on">s</span>
+    <div data-bind="visible: settings.plugin.continuousprint.failure_recovery_enabled">
+      <p>
+        Read more about failure recovery settings in the <a href="https://smartin015.github.io/continuousprint/failure-recovery/" target="_blank">Failure Recovery guide</a>.
+      <div class="control-group">
+        <label class="control-label">Enable restart on pause</label>
+        <div class="controls">
+          <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.continuousprint.cp_restart_on_pause_enabled"/>
+              Repeat current queued print when state is <code>PAUSED</code>
+          </label>
         </div>
       </div>
-    </div>
-    <div class="control-group">
-      <label class="control-label">Give up after</label>
-      <div class="controls">
-        <div class="input-append">
-          <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_restarts"/>
-          <span class="add-on">restarts</span>
+      <div class="control-group">
+        <label class="control-label">Do nothing if printing &gt;</label>
+        <div class="controls">
+          <div class="input-append">
+            <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_seconds"/>
+            <span class="add-on">s</span>
+          </div>
+        </div>
+      </div>
+      <div class="control-group">
+        <label class="control-label">Give up after</label>
+        <div class="controls">
+          <div class="input-append">
+            <input type="number" step="any" min="0" class="input-mini text-right" data-bind="value: settings.plugins.continuousprint.cp_restart_on_pause_max_restarts"/>
+            <span class="add-on">restarts</span>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/advanced-queuing.md
+++ b/docs/advanced-queuing.md
@@ -24,7 +24,7 @@ Let's consider an empty queue. If you add `A.gcode` with 5 copies and `B.gcode` 
 
 `AAAAA BBBBB`
 
-This is great if you want all of your `A` files to print before all your `B` files, for instance when you're working on a project that uses `A` but plan use `B` for something later. 
+This is great if you want all of your `A` files to print before all your `B` files, for instance when you're working on a project that uses `A` but plan use `B` for something later.
 
 ## Example 2: Interleaved strategy
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,7 +52,7 @@ fields may be subject to change without notice, so be wary of depending on them.
 
 Payload: `active=true` or `active=false`
 
-This starts and stops continuous print management of the printer. 
+This starts and stops continuous print management of the printer.
 
 !!! warning
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,10 @@
 # Contributor Guide
 
-*Based on the [octoprint plugin quickstart guide](https://docs.octoprint.org/en/master/plugins/gettingstarted.html)*
+Follow these steps if you'd like to set up a development environment for contributing changes back to Continuous Print.
+
+If you just want to run the plugin, see [Getting Started](/getting-started/).
+
+*This guide is based on the [octoprint plugin quickstart guide](https://docs.octoprint.org/en/master/plugins/gettingstarted.html)*
 
 ## 1. Install octoprint from source
 
@@ -14,27 +18,48 @@ source venv/bin/activate
 pip install -e .
 ```
 
-## 2. Install and start the continuous print plugin in local dev mode
+## 2. Install dev tools
 
-In the same terminal as the one where you activated the environment, Install the plugin in dev mode and launch the server:
+!!! important
 
-```shell
+    Perform this step **in a different terminal** - NOT using the venv we set up for OctoPrint. The
+    dev dependencies are known to conflict with OctoPrint's dependencies and can break your OctoPrint installation.
+
+```
 git clone https://github.com/smartin015/continuousprint.git
 cd continuousprint
-octoprint dev plugin:install
 pip install -r dev-dependencies.txt
-pre-commit install  # Cleans up files when you commit them - see https://pre-commit.com/. Note that venv must be activated or else flake8 raises improper errors
+pre-commit install
+```
+
+You can verify good installation by running `pre-commit run --all-files`. If everything passes, you're good to go.
+
+## 2. Install and start the continuous print plugin in local dev mode
+
+In the same terminal as the one where you activated the environment (see step 1), install the plugin in dev mode and launch the server:
+
+```shell
+cd ../continuousprint
+octoprint dev plugin:install
 octoprint serve
 ```
 
 You should see "Successfully installed continuousprint" when running the install command, and you can view the page at [http://localhost:5000](http://localhost:5000).
 
+### Editing docs
+
+Continuous Print uses [mkdocs](https://www.mkdocs.org/) to generate web documentation. All documentation lives in `docs/`.
+
+if you installed the dev tools (step 2) you can run `mkdocs serve` from the root of the repository to see doc edits live at [http://localhost:8000](http://localhost:8000).
+
 ## 3. Run unit tests to verify changes
 
-Backend unit tests are currently run manually:
+When you've made your changes, it's important to test for regressions. 
+
+Run python tests with this command:
+
 ```
-python3 continuousprint/print_queue_test.py
-python3 continuousprint/driver_test.py
+python3 -m unittest *_test.py
 ```
 
 Frontend unit tests require some additional setup (make sure [yarn](https://classic.yarnpkg.com/lang/en/docs/install/#debian-stable) and its dependencies are installed):
@@ -64,7 +89,7 @@ Note that we're using the bundled version of python3 that comes with octoprint, 
 
 ## Tips and Tricks
 
-This is a collection of random tidbits intended to help you get your bearings. If you're new to this plugin (and/or plugin development in general), please take a look!
+This is a collection of random tidbits intended to help you get your bearings.
 
 * The backend (`__init__.py` and dependencies) stores a flattened representation of the print queue and
   iterates through it from beginning to end. Each item is loaded as a QueueItem (see `print_queue.py`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,6 +22,7 @@ In the same terminal as the one where you activated the environment, Install the
 git clone https://github.com/smartin015/continuousprint.git
 cd continuousprint
 octoprint dev plugin:install
+pip install -r dev-dependencies.txt
 pre-commit install  # Cleans up files when you commit them - see https://pre-commit.com/. Note that venv must be activated or else flake8 raises improper errors
 octoprint serve
 ```
@@ -77,4 +78,3 @@ This is a collection of random tidbits intended to help you get your bearings. I
     * Applied fix from https://github.com/SortableJS/knockout-sortablejs/pull/13
     * Applied fix from https://github.com/SortableJS/knockout-sortablejs/issues/14
     * Discussion at https://github.com/smartin015/continuousprint/issues/14 (conflict with a different `knockout-sortable` library)
-

--- a/docs/failure-recovery.md
+++ b/docs/failure-recovery.md
@@ -1,0 +1,29 @@
+# Failure Recovery
+
+Sometimes, printers don't do what they're told.
+
+Follow the steps in this guide to help Continuous Print recover from unexpected printing behavior.
+
+## Spaghetti Detection and Recovery
+
+By default, the print queue doesn't know whether your print is proceeding fine or spraying filament everywhere ("spaghettification"). 
+
+Follow [The Spaghetti Detective installation instructions](https://www.thespaghettidetective.com/docs/octoprint-plugin-setup/) on your octoprint installation, then restart OctoPrint. Continuous Print will automatically detect that TSD is installed and will enable queue recovery when spaghetti is detected (TSD plugin must be `v1.8.11` or higher).
+
+When TSD thinks the print is failing:
+
+1. Continuous Print checks how long the current print has been running. If the failure was detected late into the print, the queue will pause and wait for user input. 
+2. Otherwise, it looks to see how many time this specific print has been attempted. If it's been tried too many times, the queue pauses and waits for user input.
+3. Otherwise, run the failure clearing script and try the print again.
+
+In the case of #1, TSD can cause false-positives, so this saves print time and filament even if it's a bit more manual.
+
+For #2, either the printer isn't adhesive enough or the print itself is at fault. [Further development](https://github.com/smartin015/continuousprint/issues/37) may improve behavior here, e.g. attempting the next print in the queue before giving up in case the print itself is at fault.
+
+### Configuration
+
+By going to Settings -> Continuous Print and scrolling down to "Failure Recovery", you can adjust:
+
+* The amount of time a print can run before Continuous Print pauses the qeueue on failure
+* The number of allowed retries before stopping the queue
+

--- a/docs/gcode-scripting.md
+++ b/docs/gcode-scripting.md
@@ -1,0 +1,83 @@
+# GCODE Scripting Exapmles
+
+GCODE scripts can be quite complex - if you want to learn the basics, try reading through [this primer](https://www.simplify3d.com/support/articles/3d-printing-gcode-tutorial/).
+
+## Bed cleaing scripts
+
+When Continuous Print is managing the queue, this script is run after every print completes - **including prints started before queue managing begins**. 
+
+Your cleaning script should remove all 3D print material from the build area to make way for the next print.
+
+### Gantry Sweep
+
+This script example assumes a box style printer with a vertical Z axis and a `200mm x 235mm` XY build area. It uses the printer's extruder to
+push the part off the build plate.
+
+```
+M17 ;enable steppers
+G91 ; Set relative for lift
+G0 Z10 ; lift z by 10
+G90 ;back to absolute positioning
+M190 R25 ; set bed to 25 and wait for cooldown
+G0 X200 Y235 ;move to back corner
+G0 X110 Y235 ;move to mid bed aft
+G0 Z1 ;come down to 1MM from bed
+G0 Y0 ;wipe forward
+G0 Y235 ;wipe aft
+G28 ; home
+```
+
+### Advance Belt
+
+This script works with a belt printer (specifically, a [Creality CR-30](https://www.creality.com/goods-detail/creality-3dprintmill-3d-printer)). The belt is advanced to move the print out of the way before starting another print.
+
+```
+M17 ; enable steppers
+G91 ; Set relative for lift
+G21 ; Set units to mm
+G0 Z10 ; advance bed (Z) by 10mm
+G90 ; back to absolute positioning
+M104 S0; Set Hot-end to 0C (off)
+M140 S0; Set bed to 0C (off)
+```
+
+### Wait for Input
+
+Use this script if you want to remove the print yourself but use the queue to keep track of your prints. It uses an [`@ Command`](https://docs.octoprint.org/en/master/features/atcommands.html) to tell OctoPrint to pause the print. The printer will stay paused until you press "Resume" on the OctoPrint UI.
+
+```
+M18 ; disable steppers
+M104 T0 S0 ; extruder heater off
+M140 S0 ; heated bed heater off
+@pause ; wait for user input
+```
+
+## Queue finished scripts
+
+This script is run after all prints in the queue have been printed. Use this script to put the machine in a safe resting state. Note that the last print will have already been cleared by the bed cleaning script (above).
+
+### Generic
+
+This is a generic "heaters and motors off" script which should be compatible with most printers.
+
+```
+M18 ; disable steppers
+M104 T0 S0 ; extruder heater off
+M140 S0 ; heated bed heater off
+M300 S880 P300 ; beep to show its finished
+```
+
+### Advance Belt
+
+This matches the "Advance Belt" script above.
+
+```
+M17 ; enable steppers
+G91 ; Set relative for lift
+G21 ; Set units to mm
+G0 Z300 ; advance bed (Z) to roll off all parts
+M18 ; Disable steppers
+G90 ; back to absolute positioning
+M104 S0; Set Hot-end to 0C (off)
+M140 S0; Set bed to 0C (off)
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ That's it! Now let's configure it to work with your printer.
 
 !!! tip "Want cool features?"
 
-    There's [much more automation on the way](github.com/smartin015/continuousprint/issues)! 
+    There's [much more automation on the way](github.com/smartin015/continuousprint/issues)!
 
     To help speed up development and get features early (and if you don't mind the odd bug here and there), turn on `Release Candidates` under `Settings -> Software Update` (more info [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402))
 
@@ -33,9 +33,9 @@ The queue is actually made up of two levels: sets and jobs.
 
 **Sets** are a single print file, printed one or more times. You created a set by following the "Add prints to the queue" step above.
 
-**Jobs** are a collection of sets, printed one or more times. 
+**Jobs** are a collection of sets, printed one or more times.
 
-By default, every print file you add (as a set) is appended to a default, unnamed job at the end of the queue. If you give this job a name (by clicking the title box, typing a name, then hitting enter or clicking away) it will stop collecting new prints and a new default job will be created 
+By default, every print file you add (as a set) is appended to a default, unnamed job at the end of the queue. If you give this job a name (by clicking the title box, typing a name, then hitting enter or clicking away) it will stop collecting new prints and a new default job will be created
 
 **Example 1: Batched**
 
@@ -43,7 +43,7 @@ Let's consider an empty queue. If you add `A.gcode` with 5 copies and `B.gcode` 
 
 `A A A A A B B B B B`
 
-This is great if you want all of your `A` files to print before all your `B` files, e.g. if you're working on a project that uses `A` but plan use `B` for something later. 
+This is great if you want all of your `A` files to print before all your `B` files, e.g. if you're working on a project that uses `A` but plan use `B` for something later.
 
 **Example 2: Interleaved**
 
@@ -53,7 +53,7 @@ Let's start again with an empty queue, but now suppose we add `A.gcode` with 1 c
 
 This is exactly the pattern you would want if you were, for example, printing a box with `A.gcode` as the base and `B.gcode` as the lid. Each box would be completed in order, so you can use the first box without waiting for all the bases to print, then for the first lid to print.
 
-You can mix and match 
+You can mix and match
 
 ## Start the queue
 
@@ -62,7 +62,7 @@ You can mix and match
     If you glossed over "Configure the plugin" above, read it now. Seriously.
 
     You can permanently damage your printer if you don't set up the correct GCODE instructions to a
-    clear the bed and finish the queue. 
+    clear the bed and finish the queue.
 
     Supporting specific printer profiles is [on the to-do list](https://github.com/smartin015/continuousprint/issues/21), but not yet available, so you'll have to do this on your own for now.
 
@@ -88,8 +88,8 @@ When all prints are finished, the plugin stops managing the queue and waits for 
 
 If you need to stop early, click `Stop Managing`.
 
-!!! important 
-    
+!!! important
+
     The queue may not be managed any more, but **any currently running print will continue printing**  unless you cancel it with the `Cancel` button.
 
 ## Clean up the queue
@@ -98,9 +98,6 @@ Click the triple-dot menu in the top right corner of the plugin tab for several 
 
 ## Troubleshooting
 
-If at any point you're stuck or see unexpected behavior or bugs, please file a [bug report](https://github.com/smartin015/continuousprint/issues/new?assignees=&labels=bug&template=bug_report.md&title=). 
+If at any point you're stuck or see unexpected behavior or bugs, please file a [bug report](https://github.com/smartin015/continuousprint/issues/new?assignees=&labels=bug&template=bug_report.md&title=).
 
 **Be sure to include system info and browser logs** so the problem can be quickly diagnosed and fixed.
-
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 ![build status](https://img.shields.io/travis/smartin015/continuousprint/master?style=plastic)
 ![code coverage](https://img.shields.io/codecov/c/github/smartin015/continuousprint/master)
 
-Thanks for your interest in the OctoPrint Continuous Print plugin! 
+Thanks for your interest in the OctoPrint Continuous Print plugin!
 
 For an overview, check out the [plugin repository page](https://plugins.octoprint.org/plugins/continuousprint/).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,14 +2,14 @@ site_name: Continuous Print
 theme:
   name: material
   palette:
-    - media: "(prefers-color-scheme: light)" 
+    - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: green
       accent: indigo
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)" 
+    - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: green
       accent: indigo
@@ -18,9 +18,11 @@ theme:
         name: Switch to light mode
 markdown_extensions:
   - admonition
-nav: 
+nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - GCODE Scripting: gcode-scripting.md
   - Advanced Queuing: advanced-queuing.md
+  - Failure Recovery: failure-recovery.md
   - Contributing: contributing.md
   - API: api.md

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "jest": "^27.4.7",
-    "knockout": "^3.5.1"
+    "knockout": "^3.5.1",
+    "prettier": "2.6.0"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "continuousprint"
 plugin_name = "continuousprint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.5.0rc1"
+plugin_version = "1.5.0rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,7 @@ plugin_url = "https://github.com/smartin015/continuousprint"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = [
-    "pre-commit",  # For running automated precommit scripts 
-    "mkdocs-material",  # Theme for documentation
-    "mkdocs",  # Documentation library
-    "pymdown-extensions",  # Fancy extensions for documentation
-]
+plugin_requires = []
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
For #37, auto-enable failure recovery and use TSD external events changes from latest plugin release. Add doc for how to enable/configure.

For #21, further improved docs to include gcode examples, as a low-tech substitute for storing actual printer profiles.