### PR TITLE
Proper UX and queue behavior when deleting referenced files

### DIFF
--- a/continuousprint/static/js/continuousprint_set.js
+++ b/continuousprint/static/js/continuousprint_set.js
@@ -21,6 +21,7 @@ function CPSet(data, job, api, profile) {
     return self.path().split(/[\\/]/).pop();
   });
   self.count = ko.observable(data.count);
+  self.missing_file = ko.observable(data.missing_file);
   self.remaining = ko.observable((data.remaining !== undefined) ? data.remaining : data.count);
   self.completed = ko.observable(data.count - self.remaining()); // Not computed to allow for edits without changing
   self.expanded = ko.observable(data.expanded);

--- a/continuousprint/static/js/continuousprint_viewmodel.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.js
@@ -68,6 +68,33 @@ function CPViewModel(parameters) {
     self.files.add = function(data) {
       self.defaultQueue.addFile(data);
     };
+    // Also patch file deletion, to show a modal if the file is in the queue
+    let oldRemove = self.files.removeFile;
+    let remove_cb = null;
+    self.files.removeFile = function(data, evt) {
+      for (let j of self.defaultQueue.jobs()) {
+        for (let s of j.sets()) {
+          if (s.path() === data.path) {
+            remove_cb = () => oldRemove(data, evt);
+            return self.showRemoveConfirmModal()
+          }
+        }
+      }
+      return oldRemove(data, evt);
+    };
+		self.rmDialog = $("#cpq_removeConfirmDialog");
+    self.showRemoveConfirmModal = function() {
+			self.rmDialog.modal({}).css({
+					width: 'auto',
+					'margin-left': function() { return -($(this).width() /2); }
+			});
+    }
+    self.removeConfirm = function() {
+      remove_cb();
+      remove_cb = null;
+      self._loadState(); // Refresh to get new "file missing" states
+			self.rmDialog.modal('hide');
+    };
 
     // Patch the files panel to prevent selecting/printing .gjob files
     let oldEnableSelect = self.files.enableSelect;

--- a/continuousprint/storage/database.py
+++ b/continuousprint/storage/database.py
@@ -73,20 +73,28 @@ class JobView:
         if self.remaining > 0:
             self.refresh_sets()
 
-    def next_set(self, profile):
+    def next_set(self, profile, custom_filter=None):
         if self.draft or self.queue.name == ARCHIVE_QUEUE or self.remaining == 0:
             return None
 
-        nxt = self._next_set(profile)
-        if nxt is None:  # We may need to decrement to actually get the next set
+        nxt, any_printable = self._next_set(profile, custom_filter)
+        # We may need to decrement to actually get the next set
+        # but we don't touch the job if there aren't any compatible/printable sets to begin with
+        if nxt is None and any_printable:
             self.decrement()
-            nxt = self._next_set(profile)
+            nxt = self._next_set(profile, custom_filter)
         return nxt
 
-    def _next_set(self, profile):
+    def _next_set(self, profile, custom_filter):
+        any_printable = False
         for s in self.sets:
-            if s.is_printable(profile):
-                return s
+            if custom_filter is not None and not custom_filter(s):
+                continue
+            printable = s.is_printable(profile)
+            any_printable = any_printable or printable
+            if s.remaining > 0 and printable:
+                return (s, None)
+        return (None, any_printable)
 
     @classmethod
     def from_dict(self, data: dict):
@@ -154,7 +162,7 @@ class SetView:
 
     def is_printable(self, profile):
         profs = self.profiles()
-        if self.remaining > 0 and (len(profs) == 0 or profile["name"] in profs):
+        if len(profs) == 0 or profile["name"] in profs:
             return True
         return False
 

--- a/continuousprint/storage/database_test.py
+++ b/continuousprint/storage/database_test.py
@@ -132,6 +132,12 @@ class TestJobWithSet(DBTest):
         self.j.draft = True
         self.assertEqual(self.j.next_set(dict(name="baz")), None)
 
+    def testNextSetWithCustomFilterReject(self):
+        self.assertEqual(self.j.next_set(dict(name="baz"), lambda s: False), None)
+
+    def testNextSetWithCustomFilterAccept(self):
+        self.assertEqual(self.j.next_set(dict(name="baz"), lambda s: True), self.s)
+
     def testNextSetWithDifferentProfile(self):
         self.assertEqual(self.j.next_set(dict(name="bar")), None)
 

--- a/continuousprint/storage/queries.py
+++ b/continuousprint/storage/queries.py
@@ -129,9 +129,11 @@ def getJob(jid):
     return Job.get(id=jid)
 
 
-def getNextJobInQueue(q, profile):
+def getNextJobInQueue(q, profile, custom_filter=None):
     for job in getJobsAndSets(q):
-        ns = job.next_set(profile)  # Only return a job which has a compatible next set
+        ns = job.next_set(
+            profile, custom_filter
+        )  # Only return a job which has a compatible next set
         if ns is not None:
             return job
 

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -25,6 +25,23 @@
         <button class="btn btn-danger btn-confirm" data-bind="click: submitJob">Confirm</button>
     </div>
 </div>
+<div id="cpq_removeConfirmDialog" class="modal hide fade">
+    <div class="modal-header">
+      <h3 class="modal-title">File exists in queue. Are you sure?</h3>
+    </div>
+    <div class="modal-body">
+        <p>
+          The file is currently present in the Continuous Print Queue.
+        <p>
+        <p>
+          If you delete this file, its queue entries will be skipped.
+        </p>
+    </div>
+    <div class="modal-footer">
+        <button class="btn btn-cancel" data-dismiss="modal" aria-hidden="true">Cancel</button>
+        <button class="btn btn-danger btn-confirm" data-bind="click: removeConfirm">Confirm</button>
+    </div>
+</div>
 
 <ul class="nav nav-tabs">
   <li class="active"><a href="#continuousprint_tab_queues" data-toggle="tab">Queues</a></li>
@@ -169,10 +186,14 @@
                           <span data-bind="text: shortName"/>
                         </p>
                         <!-- ko if: !job.draft() -->
-                        <div style="width: 150px; text-align: center;" data-bind="hidden: profile_matches" title="Set profile doesn't match this printer and will be skipped">
+                        <div style="width: 150px; text-align: center;" data-bind="hidden: profile_matches() || missing_file()" title="Set profile doesn't match this printer and will be skipped">
                           <i class="fas fa-angle-double-right"  style="margin-top: 3px; opacity: 0.5;"></i>
                         </div>
-                        <div class="progress" data-bind="hidden: !profile_matches(), css: { 'progress-striped active': queue.active_sets().indexOf(id) !== -1 }">
+                        <div style="width: 150px; text-align: center;" data-bind="hidden: !missing_file()" title="File is missing; this will be skipped">
+                          <i class="fas fa-exclamation-triangle" style="color: #aa0000"></i>
+                        </div>
+
+                        <div class="progress" data-bind="hidden: !profile_matches() || missing_file(), css: { 'progress-striped active': queue.active_sets().indexOf(id) !== -1 }">
                           <div data-bind="visible: pct_complete() !== '0%', style: { width: pct_complete() }" class="bar bar-success"></div>
                           <div data-bind="visible: queue.active_sets().indexOf(id) !== -1, style: { width: pct_active() }" class="bar active"></div>
                         </div>


### PR DESCRIPTION
A long-needed improvement for file deletion originally referenced in #7, this PR:

* Patches the file deletion button and throws up a confirmation dialog when the file being deleted is referenced in the print queue.
* Changes behavior when selecting jobs/sets, skipping over sets where the file is not present on disk.
* Includes a new `missing_file` attribute per-set for the local queue, which displays a warning icon on for sets where the file is missing.


Still todo:

* [ ] Add unit tests to confirm sane next_set behavior (and getNextJobInQueue)
* [ ] Add unit tests of file confirmation modal conditions