### PR TITLE
Timelapse autodelete / history linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7
 
+# Installing ffmpeg is needed for working with timelapses - this can be ommitted otherwise
+RUN apt-get update && apt-get -y install --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+
 RUN adduser oprint
 USER oprint
 

--- a/continuousprint/data/__init__.py
+++ b/continuousprint/data/__init__.py
@@ -30,6 +30,10 @@ class Keys(Enum):
     BED_COOLDOWN_TIMEOUT = ("bed_cooldown_timeout", 60)
     MATERIAL_SELECTION = ("cp_material_selection_enabled", False)
     NETWORK_NAME = ("cp_network_name", "Generic")
+    AUTOMATION_TIMELAPSE_ACTION = (
+        "cp_automation_timelapse_action",
+        "do_nothing",
+    )  # One of "do_nothing", "auto_remove"
     UPLOAD_ACTION = (
         "cp_upload_action",
         "do_nothing",

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -366,6 +366,30 @@
   text-align: center;
 }
 
+#tab_plugin_continuousprint .timelapse_thumbnail {
+	position: relative;
+	display: inline-block;
+}
+
+#tab_plugin_continuousprint .timelapse_thumbnail > img {
+	display: none;
+	cursor: pointer;
+	position: absolute;
+	z-index: 1000;
+	top: 0;
+	max-width: 100px;
+	left: 18px;
+	border: 1px black solid;
+	padding: 5px;
+	background-color: white;
+}
+#tab_plugin_continuousprint .timelapse_thumbnail > i {
+	padding: 2px; /* So hover is maintained when mousing over to image */
+}
+#tab_plugin_continuousprint .timelapse_thumbnail:hover > img {
+  display: block;
+}
+
 #tab_plugin_continuousprint .separator {
   display: flex;
   justify-content: space-between;

--- a/continuousprint/static/js/continuousprint_history_row.js
+++ b/continuousprint/static/js/continuousprint_history_row.js
@@ -39,6 +39,17 @@ function CPHistoryRow(data) {
     }
     return "in progress";
   });
+
+  if (data.movie_path && data.thumb_path) {
+    let movie_base = data.movie_path.split("/").pop();
+    let thumb_base = data.thumb_path.split("/").pop();
+    self.movieURL = ko.observable("/downloads/timelapse/" + encodeURIComponent(movie_base));
+    self.thumbURL = ko.observable("/downloads/timelapse/" + encodeURIComponent(thumb_base));
+  } else {
+    self.movieURL = ko.observable();
+    self.thumbURL = ko.observable();
+  }
+
   self.icon_class = ko.computed(function() {
     let r = self.result();
     switch (r) {
@@ -52,6 +63,11 @@ function CPHistoryRow(data) {
         return "";
     }
   });
+
+  self.showTimelapse = function() {
+    // Hook into the exiting TimelapseViewModel so we don't have to write our own preview code.
+    ko.dataFor($("#timelapse").get(0)).showTimelapsePreview({url: self.movieURL()});
+  }
 
   function pluralize(num, unit) {
     num = Math.round(num);

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -358,6 +358,8 @@ class TestMultiItemQueue(DBTest):
                     "run_id": 2,
                     "set_path": "b.gcode",
                     "queue_name": DEFAULT_QUEUE,
+                    "movie_path": None,
+                    "thumb_path": None,
                     "start": ANY,
                 },
                 {
@@ -367,6 +369,8 @@ class TestMultiItemQueue(DBTest):
                     "run_id": 1,
                     "set_path": "a.gcode",
                     "queue_name": DEFAULT_QUEUE,
+                    "movie_path": None,
+                    "thumb_path": None,
                     "start": ANY,
                 },
             ],
@@ -378,3 +382,12 @@ class TestMultiItemQueue(DBTest):
         self.assertNotEqual(Run.select().count(), 0)
         q.resetHistory()
         self.assertEqual(Run.select().count(), 0)
+
+    def testAnnotateLastRun(self):
+        s = Set.get(id=1)
+        r = q.beginRun(DEFAULT_QUEUE, s.job.name, s.path)
+        q.endRun(r, "success")
+        q.annotateLastRun(s.path, "movie_path.mp4", "thumb_path.png")
+        r = Run.get(id=r.id)
+        self.assertEqual(r.movie_path, "movie_path.mp4")
+        self.assertEqual(r.thumb_path, "thumb_path.png")

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -255,6 +255,16 @@
             </select>
           </div>
         </div>
+        <div class="control-group" title="How to handle time lapses when running automation scripts">
+          <label class="control-label">Clearing/Finishing Timelapses</label>
+          <div class="controls">
+            <select data-bind="value: settings.settings.plugins.continuousprint.cp_automation_timelapse_action">
+              <option value="do_nothing">Do nothing</option>
+              <option value="auto_remove">Auto-remove</option>
+            </select>
+          </div>
+        </div>
+      </fieldset>
     </form>
   </div> <!-- settings_continuousprint_lan -->
 

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -74,9 +74,13 @@
       <!-- /ko -->
       <!-- ko ifnot: $data.divider -->
       <div class="entry" data-bind="css: {'success': result().startsWith('success')}">
-          <div>
+          <div style="text-align: left">
             <i data-bind="css: icon_class"></i>
             <span data-bind="text:result"></span>
+            <div class="timelapse_thumbnail" data-bind="visible: thumbURL">
+              <i class="fas fa-film"></i>
+              <img data-bind="attr: {src: thumbURL}, click: showTimelapse"></img>
+            </div>
           </div>
           <div data-bind="text:duration"></div>
           <div data-bind="text:startedDate"></div>


### PR DESCRIPTION
This closes #30 by:

* Adding a setting for auto-deleting bed clearing and finishing timelapses to reduce clutter (defaults to "do nothing" to preserve user data).
* Annotating previous queue runs upon timelapse render completion and showing a rollover thumbnail (with clickable preview) in the history tab.

This comes with a small DB schema version bump to add two additional columns to the Run model (movie_path, thumb_path).