### PR TITLE
Fix some edge cases 

### DIFF
--- a/continuousprint/analysis.py
+++ b/continuousprint/analysis.py
@@ -1,4 +1,4 @@
-from octoprint.filemanager.analysis import AbstractAnalysisQueue
+from octoprint.filemanager.analysis import AbstractAnalysisQueue, AnalysisAborted
 from octoprint.util.platform import CLOSE_FDS
 from octoprint.util import dict_merge
 

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -334,11 +334,17 @@ class CPQPlugin(ContinuousPrintAPI):
         ):  # https://docs.octoprint.org/en/master/events/index.html#file-handling
             upload_action = self._get_key(Keys.UPLOAD_ACTION, "do_nothing")
             if upload_action != "do_nothing":
-                self._add_set(
-                    path=payload["path"],
-                    sd=payload["target"] != "local",
-                    draft=(upload_action != "add_printable"),
-                )
+                if payload["path"].endswith(".gcode"):
+                    self._add_set(
+                        path=payload["path"],
+                        sd=payload["target"] != "local",
+                        draft=(upload_action != "add_printable"),
+                    )
+                elif payload["path"].endswith(".gjob"):
+                    self._get_queue(DEFAULT_QUEUE).import_job(
+                        payload["path"], draft=(upload_action != "add_printable")
+                    )
+                    self._sync_state()
             else:
                 return
 

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -208,11 +208,25 @@ class TestEventHandling(unittest.TestCase):
         self.p.on_event(Events.UPLOAD, dict())
         self.p.d.action.assert_not_called()
 
+    def testUploadAddPrintableInvalidFile(self):
+        self.p._set_key(Keys.UPLOAD_ACTION, "add_printable")
+        self.p._add_set = MagicMock()
+        self.p.on_event(Events.UPLOAD, dict(path="testpath.xlsx", target="local"))
+        self.p._add_set.assert_not_called()
+
     def testUploadAddPrintable(self):
         self.p._set_key(Keys.UPLOAD_ACTION, "add_printable")
         self.p._add_set = MagicMock()
-        self.p.on_event(Events.UPLOAD, dict(path="testpath", target="local"))
-        self.p._add_set.assert_called_with(draft=False, sd=False, path="testpath")
+        self.p.on_event(Events.UPLOAD, dict(path="testpath.gcode", target="local"))
+        self.p._add_set.assert_called_with(draft=False, sd=False, path="testpath.gcode")
+
+    def testUploadAddPrintableGJob(self):
+        self.p._set_key(Keys.UPLOAD_ACTION, "add_printable")
+        self.p._add_set = MagicMock()
+        self.p.on_event(Events.UPLOAD, dict(path="testpath.gjob", target="local"))
+        self.p._get_queue(DEFAULT_QUEUE).import_job.assert_called_with(
+            "testpath.gjob", draft=False
+        )
 
     def testTempFileMovieDone(self):
         self.p._set_key(Keys.AUTOMATION_TIMELAPSE_ACTION, "auto_remove")

--- a/continuousprint/queues/local.py
+++ b/continuousprint/queues/local.py
@@ -117,13 +117,13 @@ class LocalQueue(AbstractEditableQueue):
     def rm_multi(self, job_ids=[], set_ids=[]) -> dict:
         return self.queries.remove(job_ids=job_ids, set_ids=set_ids)
 
-    def import_job(self, gjob_path: str) -> dict:
+    def import_job(self, gjob_path: str, draft=True) -> dict:
         out_dir = str(Path(gjob_path).stem)
         self._mkdir(out_dir)
         manifest, filepaths = unpack_job(
             self._path_on_disk(gjob_path), self._path_on_disk(out_dir)
         )
-        return self.queries.importJob(self.ns, manifest, out_dir)
+        return self.queries.importJob(self.ns, manifest, out_dir, draft)
 
     def export_job(self, job_id: int, dest_dir: str) -> str:
         j = self.queries.getJob(job_id)

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -126,6 +126,16 @@ class TestSingleItemQueue(DBTest):
         q.updateJob(1, dict(sets=[dict(id=1, profiles=["a", "b"])]))
         self.assertEqual(Set.get(id=1).profiles(), ["a", "b"])
 
+    def testUpdateJobIncrementCompleted(self):
+        # Incrementing the count of a completed job should refresh all sets within the job
+        j = Job.get(id=1)
+        s = Set.get(id=1)
+        s.remaining = 0
+        s.save()
+
+        q.updateJob(1, dict(count=j.count + 1))
+        self.assertEqual(Set.get(id=1).remaining, 1)
+
     def testRemoveJob(self):
         q.remove(job_ids=[1])
         self.assertEqual(len(q.getJobsAndSets(DEFAULT_QUEUE)), 0)  # No jobs or sets


### PR DESCRIPTION
* .gjob drag-drop with auto-add turned on now properly unpacks the job
* Increasing the job count now refreshes sets if the job is fully complete - preventing fencepost error where only N-1 new iterations  occurred