### PR TITLE
Analysis & concurrency fixes

### DIFF
--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -15,7 +15,6 @@ from .data import (
 from .storage import queries
 from .api import Permission as CPQPermission
 from .plugin import CPQPlugin
-from .analysis import CPQProfileAnalysisQueue
 
 
 class ContinuousprintPlugin(
@@ -126,10 +125,6 @@ class ContinuousprintPlugin(
     def support_gjob_format(*args, **kwargs):
         return dict(machinecode=dict(gjob=["gjob"]))
 
-    def cpq_analysis_queue(*args, **kwargs):
-        result = dict(gcode=CPQProfileAnalysisQueue)
-        return result
-
 
 __plugin_name__ = "Continuous Print"
 __plugin_pythoncompat__ = ">=3.7,<4"
@@ -145,5 +140,4 @@ def __plugin_load__():
         "octoprint.access.permissions": __plugin_implementation__.add_permissions,
         "octoprint.comm.protocol.action": __plugin_implementation__.resume_action_handler,
         "octoprint.filemanager.extension_tree": __plugin_implementation__.support_gjob_format,
-        "octoprint.filemanager.analysis.factory": __plugin_implementation__.cpq_analysis_queue,
     }

--- a/continuousprint/analysis.py
+++ b/continuousprint/analysis.py
@@ -57,7 +57,7 @@ class CPQProfileAnalysisQueue(AbstractAnalysisQueue):
             self._logger.info(f"Got output: {output!r}")
 
             result = {}
-            result["profile"] = output.strip()
+            result[self.PROFILE_KEY] = output.strip()
 
             if self._current.analysis and isinstance(self._current.analysis, dict):
                 return dict_merge(result, self._current.analysis)

--- a/continuousprint/analysis.py
+++ b/continuousprint/analysis.py
@@ -6,7 +6,8 @@ from octoprint.util import dict_merge
 class CPQProfileAnalysisQueue(AbstractAnalysisQueue):
     """This queue attempts to resolve the profiles for which a gcode has been created."""
 
-    PROFILE_KEY = "continuousprint_profile"
+    META_KEY = "continuousprint"
+    PROFILE_KEY = "profile"
 
     def __init__(self, finished_callback):
         AbstractAnalysisQueue.__init__(self, finished_callback)
@@ -56,7 +57,7 @@ class CPQProfileAnalysisQueue(AbstractAnalysisQueue):
             self._logger.info(f"Got output: {output!r}")
 
             result = {}
-            result[self.PROFILE_KEY] = output.strip()
+            result["profile"] = output.strip()
 
             if self._current.analysis and isinstance(self._current.analysis, dict):
                 return dict_merge(result, self._current.analysis)

--- a/continuousprint/driver_test.py
+++ b/continuousprint/driver_test.py
@@ -71,6 +71,17 @@ class TestFromInactive(unittest.TestCase):
         self.assertEqual(self.d.state.__name__, self.d._state_start_clearing.__name__)
         self.d._runner.clear_bed.assert_not_called()
 
+    def test_idle_while_printing(self):
+        self.d.state = self.d._state_printing
+        # First idle tick does nothing
+        self.d.action(DA.TICK, DP.IDLE)
+        self.assertEqual(self.d.state.__name__, self.d._state_printing.__name__)
+
+        # Continued idleness triggers failure (retry behavior validated in test_retry_after_failure)
+        self.d.idle_start_ts = time.time() - (Driver.PRINTING_IDLE_BREAKOUT_SEC + 1)
+        self.d.action(DA.TICK, DP.IDLE)
+        self.assertEqual(self.d.state.__name__, self.d._state_failure.__name__)
+
     def test_retry_after_failure(self):
         self.d.state = self.d._state_failure
         self.d.retries = self.d.max_retries - 2

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -71,7 +71,6 @@ class CPQPlugin(ContinuousPrintAPI):
         self._init_analysis_queue()
 
     def _on_queue_update(self, q, now=time.time()):
-        self._logger.debug("_on_queue_update")
         self._sync_state()
 
     def _on_settings_updated(self):

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -311,15 +311,19 @@ class CPQPlugin(ContinuousPrintAPI):
         self._update(DA.DEACTIVATE)  # Initializes and passes printer state
         self._on_settings_updated()
 
-    def _init_analysis_queue(self):
+    def _init_analysis_queue(self, cls=AnalysisQueue, async_backlog=True):
         self._logger.debug("Creating CPQ analysis queue and checking for backlog")
-        self._analysis_queue = AnalysisQueue(dict(gcode=CPQProfileAnalysisQueue))
+        self._analysis_queue = cls(dict(gcode=CPQProfileAnalysisQueue))
         self._analysis_queue.register_finish_callback(self._on_analysis_finished)
-        import threading
 
-        thread = threading.Thread(target=self._enqueue_analysis_backlog)
-        thread.daemon = True
-        thread.start()
+        if async_backlog:
+            import threading
+
+            thread = threading.Thread(target=self._enqueue_analysis_backlog)
+            thread.daemon = True
+            thread.start()
+        else:
+            self._enqueue_analysis_backlog()
 
     def _profile_from_path(self, path):
         self._logger.info(f"_profile_from_path {path}")

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -170,7 +170,7 @@ class TestEventHandling(unittest.TestCase):
         )
         self.p._get_queue(DEFAULT_QUEUE).add_set.assert_not_called()
 
-    def testMetadataAnslysisFinishedWithPending(self):
+    def testMetadataAnalysisFinishedWithPending(self):
         self.p._set_key(Keys.INFER_PROFILE, True)
         self.p._file_manager.get_additional_metadata.return_value = dict()
         self.p._add_set(path="a.gcode", sd=False)  # Gets queued, no metadata
@@ -186,7 +186,7 @@ class TestEventHandling(unittest.TestCase):
                 "sd": "false",
                 "count": 1,
                 "jobDraft": True,
-                "profiles": [],
+                "profiles": ["asdf"],
             },
         )
 

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -169,11 +169,11 @@ class TestEventHandling(unittest.TestCase):
 
     def testMetadataAnslysisFinishedWithPending(self):
         self.p._set_key(Keys.INFER_PROFILE, True)
-        self.p._file_manager.get_metadata.return_value = dict()
+        self.p._file_manager.get_additional_metadata.return_value = dict()
         self.p._add_set(path="a.gcode", sd=False)  # Gets queued, no metadata
         self.p._get_queue(DEFAULT_QUEUE).add_set.assert_not_called()
         self.p.on_event(
-            Events.METADATA_ANALYSIS_FINISHED,
+            CPQPlugin.CPQ_ANALYSIS_FINISHED,
             dict(result={CPQProfileAnalysisQueue.PROFILE_KEY: "asdf"}, path="a.gcode"),
         )
         self.p._get_queue(DEFAULT_QUEUE).add_set.assert_called_with(
@@ -189,7 +189,7 @@ class TestEventHandling(unittest.TestCase):
 
     def testAddSetWithPending(self):
         self.p._set_key(Keys.INFER_PROFILE, True)
-        self.p._file_manager.get_metadata.return_value = dict()
+        self.p._file_manager.get_additional_metadata.return_value = dict()
         self.p._add_set(path="a.gcode", sd=False)  # Gets queued, no metadata
         self.p._get_queue(DEFAULT_QUEUE).add_set.assert_not_called()
         self.p._add_set(path="a.gcode", sd=False)  # Second attempt passes through

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -156,7 +156,9 @@ class TestEventHandling(unittest.TestCase):
         self.p.d.action.assert_called_with(DA.TICK, ANY, ANY, ANY, ANY)
 
     def testTickExceptionHandled(self):
-        self.p.d.action.side_effect = Exception("testing exception")
+        self.p.d.action.side_effect = Exception(
+            "testing exception - ignore this, part of a unit test"
+        )
         self.p.tick()  # does *not* raise exception
         self.p.d.action.assert_called()
 
@@ -386,14 +388,12 @@ class TestAnalysis(unittest.TestCase):
         self.p._analysis_queue.enqueue.assert_not_called()
 
     def testInitAnalysisNoBacklog(self):
-        self.p._file_manager.get_additional_metadata.return_value = dict(
-            profile="TestProfile"
-        )  # All files have analysis
         self.p._file_manager.list_files.return_value = dict(
             local=dict(
                 file1=dict(
                     type="machinecode",
                     path="a.gcode",
+                    continuousprint=dict(profile="TestProfile"),
                 )
             )
         )
@@ -402,9 +402,6 @@ class TestAnalysis(unittest.TestCase):
         self.p._analysis_queue.enqueue.assert_not_called()
 
     def testInitAnalysisWithBacklog(self):
-        self.p._file_manager.get_additional_metadata.return_value = (
-            None  # All files have no analysis
-        )
         self.p._file_manager.list_files.return_value = dict(
             local=dict(
                 file1=dict(

--- a/continuousprint/queues/lan.py
+++ b/continuousprint/queues/lan.py
@@ -136,17 +136,13 @@ class LANQueue(AbstractJobQueue):
             key=lambda j: j["created"]
         )  # Always creation order - there is no reordering in lan queue
         for data in jobs:
-            self._logger.debug(data)
             acq = data.get("acquired_by_")
             if acq is not None and acq != self.addr:
-                self._logger.debug(f"Skipping job; acquired by {acq}")
                 continue  # Acquired by somebody else, so don't consider for scheduling
             job = LANJobView(data, self)
             s = job.next_set(self._profile)
             if s is not None:
                 return (job, s)
-            else:
-                self._logger.debug(f"Skipping job {job.name}; no compatible sets")
         return (None, None)
 
     def acquire(self) -> bool:

--- a/continuousprint/scripts/extract_profile.py
+++ b/continuousprint/scripts/extract_profile.py
@@ -41,10 +41,11 @@ def token_string_match(profstr):
     scores = [len(p.intersection(c)) for c in CANDIDATES]
     sys.stderr.write(f"Scoring '{profstr}':\n")
     desc = sorted(zip(PROFILES, scores), key=lambda x: x[1], reverse=True)
-    for p, s in desc:
+    for p, s in desc[:4]:
         if s == 0:
             continue
         sys.stderr.write(f"- {p}: {s}\n")
+    sys.stderr.write("- ...\n")
     max_score = max(scores)
     if max_score < 2:
         return None

--- a/continuousprint/scripts/extract_profile.py
+++ b/continuousprint/scripts/extract_profile.py
@@ -40,8 +40,11 @@ def token_string_match(profstr):
 
     scores = [len(p.intersection(c)) for c in CANDIDATES]
     sys.stderr.write(f"Scoring '{profstr}':\n")
-    for i in range(len(scores)):
-        sys.stderr.write(f"- {PROFILES[i]}: {scores[i]}\n")
+    desc = sorted(zip(PROFILES, scores), key=lambda x: x[1], reverse=True)
+    for p, s in desc:
+        if s == 0:
+            continue
+        sys.stderr.write(f"- {p}: {s}\n")
     max_score = max(scores)
     if max_score < 2:
         return None

--- a/continuousprint/static/js/continuousprint_api.js
+++ b/continuousprint/static/js/continuousprint_api.js
@@ -58,6 +58,7 @@ class CPAPI {
   }
 
   add(type, data, cb) {
+    data = {json: JSON.stringify(data)};
     this._call(type, 'add', data, cb);
   }
 

--- a/continuousprint/static/js/continuousprint_queue.js
+++ b/continuousprint/static/js/continuousprint_queue.js
@@ -276,7 +276,8 @@ function CPQueue(data, api, files, profile) {
         };
 
         if (infer_profile) {
-          let prof = (data.gcodeAnalysis || {}).continuousprint_profile;
+          // See CPQProfileAnalysisQueue for metadata path key constants
+          let prof = (data.continuousprint || {}).profile;
           if (prof) {
             set_data.profiles = [prof];
           }

--- a/continuousprint/static/js/continuousprint_queue.test.js
+++ b/continuousprint/static/js/continuousprint_queue.test.js
@@ -125,7 +125,7 @@ test('resetSelected', () => {
 
 test('addFile (profile inference disabled)', () => {
   let v = init(njobs=0);
-  v.addFile({name: "foo", path: "foo.gcode", origin: "local", gcodeAnalysis: {continuousprint_profile: "testprof"}});
+  v.addFile({name: "foo", path: "foo.gcode", origin: "local", continuousprint: {profile: "testprof"}});
   expect(v.api.add).toHaveBeenCalledWith(v.api.SET, {
      "count": 1,
      "job": null,
@@ -138,7 +138,7 @@ test('addFile (profile inference disabled)', () => {
 
 test('addFile (profile inference enabled)', () => {
   let v = init(njobs=0);
-  v.addFile({name: "foo", path: "foo.gcode", origin: "local", gcodeAnalysis: {continuousprint_profile: "testprof"}}, true);
+  v.addFile({name: "foo", path: "foo.gcode", origin: "local", continuousprint: {profile: "testprof"}}, true);
   expect(v.api.add).toHaveBeenCalledWith(v.api.SET, {
      "count": 1,
      "job": null,


### PR DESCRIPTION
May help mitigate #109

Should fix #108

Improves logging state transition to clearing/finishing, which should help understand issues where the queue over/under-prints a job.

Testing:
* [x] Analysis backlog generation picks files without analysis and excludes those with analysis
* [x] Newly added files are queued for analysis
* [x] Analysis completion updates additional metadata and fires event