### PR TITLE
Full editable LAN queue items

### DIFF
--- a/continuousprint/api.py
+++ b/continuousprint/api.py
@@ -2,6 +2,7 @@ import octoprint.plugin
 from enum import Enum
 from octoprint.access.permissions import Permissions, ADMIN_GROUP
 from octoprint.server.util.flask import restricted_access
+from .queues.lan import ValidationError
 import flask
 import json
 from .storage import queries
@@ -188,7 +189,12 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
 
         # Transfer into dest queue first
         if dq != sq:
-            new_id = dq.import_job_from_view(sq.get_job_view(src_id))
+            try:
+                new_id = dq.import_job_from_view(sq.get_job_view(src_id))
+            except ValidationError as e:
+                return json.dumps(dict(error=str(e)))
+
+            print("Imported job from view")
             sq.remove_jobs([src_id])
             src_id = new_id
 

--- a/continuousprint/api.py
+++ b/continuousprint/api.py
@@ -188,11 +188,13 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
 
         # Transfer into dest queue first
         if dq != sq:
-            src_id = dq.import_job_from_view(sq.get_job_view(src_id))
+            new_id = dq.import_job_from_view(sq.get_job_view(src_id))
+            sq.remove_jobs([src_id])
+            src_id = new_id
 
         # Finally, move the job
         dq.mv_job(src_id, after_id)
-        return json.dumps("ok")
+        return json.dumps("OK")
 
     # PRIVATE API METHOD - may change without warning.
     @octoprint.plugin.BlueprintPlugin.route("/job/edit", methods=["POST"])
@@ -200,7 +202,8 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
     @cpq_permission(Permission.EDITJOB)
     def edit_job(self):
         data = json.loads(flask.request.form.get("json"))
-        return json.dumps(self._get_queue(DEFAULT_QUEUE).edit_job(data["id"], data))
+        q = self._get_queue(data["queue"])
+        return json.dumps(q.edit_job(data["id"], data))
 
     # PRIVATE API METHOD - may change without warning.
     @octoprint.plugin.BlueprintPlugin.route("/job/import", methods=["POST"])

--- a/continuousprint/api.py
+++ b/continuousprint/api.py
@@ -175,49 +175,24 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
         )
 
     # PRIVATE API METHOD - may change without warning.
-    @octoprint.plugin.BlueprintPlugin.route("/set/mv", methods=["POST"])
-    @restricted_access
-    @cpq_permission(Permission.EDITJOB)
-    def mv_set(self):
-        self._get_queue(DEFAULT_QUEUE).mv_set(
-            int(flask.request.form["id"]),
-            int(
-                flask.request.form["after_id"]
-            ),  # Move to after this set (-1 for beginning of job)
-            int(
-                flask.request.form["dest_job"]
-            ),  # Move to this job (null for new job at end)
-        )
-        return json.dumps("ok")
-
-    # PRIVATE API METHOD - may change without warning.
     @octoprint.plugin.BlueprintPlugin.route("/job/mv", methods=["POST"])
     @restricted_access
     @cpq_permission(Permission.EDITJOB)
     def mv_job(self):
-        self._get_queue(DEFAULT_QUEUE).mv_job(
-            int(flask.request.form["id"]),
-            int(
-                flask.request.form["after_id"]
-            ),  # Move to after this job (-1 for beginning of queue)
-        )
-        return json.dumps("ok")
+        src_id = flask.request.form["id"]
+        after_id = flask.request.form["after_id"]
+        if after_id == "":  # Treat empty string as 'none' i.e. front of queue
+            after_id = None
+        sq = self._get_queue(flask.request.form["src_queue"])
+        dq = self._get_queue(flask.request.form.get("dest_queue"))
 
-    # PRIVATE API METHOD - may change without warning.
-    @octoprint.plugin.BlueprintPlugin.route("/job/submit", methods=["POST"])
-    @restricted_access
-    @cpq_permission(Permission.ADDJOB)
-    def submit_job(self):
-        j = queries.getJob(int(flask.request.form["id"]))
-        # Submit to the queue and remove from its origin
-        err = self._get_queue(flask.request.form["queue"]).submit_job(j)
-        if err is None:
-            self._logger.debug(
-                self._get_queue(DEFAULT_QUEUE).remove_jobs(job_ids=[j.id])
-            )
-            return self._state_json()
-        else:
-            return json.dumps(dict(error=str(err)))
+        # Transfer into dest queue first
+        if dq != sq:
+            src_id = dq.import_job_from_view(sq.get_job_view(src_id))
+
+        # Finally, move the job
+        dq.mv_job(src_id, after_id)
+        return json.dumps("ok")
 
     # PRIVATE API METHOD - may change without warning.
     @octoprint.plugin.BlueprintPlugin.route("/job/edit", methods=["POST"])
@@ -267,17 +242,6 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
         return json.dumps(
             self._get_queue(flask.request.form["queue"]).remove_jobs(
                 flask.request.form.getlist("job_ids[]")
-            )
-        )
-
-    # PRIVATE API METHOD - may change without warning.
-    @octoprint.plugin.BlueprintPlugin.route("/set/rm", methods=["POST"])
-    @restricted_access
-    @cpq_permission(Permission.EDITJOB)
-    def rm_set(self):
-        return json.dumps(
-            self._get_queue(DEFAULT_QUEUE).rm_multi(
-                set_ids=flask.request.form.getlist("set_ids[]")
             )
         )
 

--- a/continuousprint/driver.py
+++ b/continuousprint/driver.py
@@ -78,12 +78,19 @@ class Driver:
         # Given that some calls to action() come from a watchdog timer, we hold a mutex when performing the action
         # so the state is updated in a thread safe way.
         with self.mutex:
-            self._logger.debug(
-                f"{a.name}, {p.name}, path={path}, materials={materials}, bed_temp={bed_temp}"
-            )
+            now = time.time()
+            if self.idle_start_ts is None or self.idle_start_ts + 15 > now:
+                extra = (
+                    f"(idle logs hidden after {self.idle_start_ts+15})"
+                    if self.idle_start_ts is not None
+                    else ""
+                )
+                self._logger.debug(
+                    f"{a.name}, {p.name}, path={path}, materials={materials}, bed_temp={bed_temp} {extra}"
+                )
 
             if p == Printer.IDLE and self.idle_start_ts is None:
-                self.idle_start_ts = time.time()
+                self.idle_start_ts = now
             elif p != Printer.IDLE and self.idle_start_ts is not None:
                 self.idle_start_ts = None
 

--- a/continuousprint/integration_test.py
+++ b/continuousprint/integration_test.py
@@ -15,6 +15,7 @@ from .queues.abstract import Strategy
 from peewee import SqliteDatabase
 from collections import defaultdict
 from peerprint.lan_queue import LANPrintQueueBase
+from peerprint.sync_objects_test import TestReplDict
 
 # logging.basicConfig(level=logging.DEBUG)
 
@@ -183,11 +184,6 @@ class LocalLockManager:
         self.locks.pop(k, None)
 
 
-class LocalJobDict(dict):
-    def set(self, k, v, **kwargs):
-        self[k] = v
-
-
 class TestLANQueue(IntegrationTest):
     """A simple in-memory integration test between DB storage layer, queuing layer, and driver."""
 
@@ -214,13 +210,14 @@ class TestLANQueue(IntegrationTest):
             self.lq.ns, self.lq.addr, MagicMock(), logging.getLogger("lantestbase")
         )
         self.lq.lan.q.locks = LocalLockManager(dict(), "lq")
-        self.lq.lan.q.jobs = LocalJobDict()
+        self.lq.lan.q.jobs = TestReplDict(lambda a, b: None)
         self.lq.lan.q.peers = dict()
 
     def test_completes_job_in_order(self):
         self.lq.lan.q.setJob(
-            "bsdf",
+            "uuid1",
             dict(
+                id="uuid1",
                 name="j1",
                 created=0,
                 sets=[
@@ -238,8 +235,9 @@ class TestLANQueue(IntegrationTest):
     def test_multi_job(self):
         for name in ("j1", "j2"):
             self.lq.lan.q.setJob(
-                f"{name}_hash",
+                f"{name}_id",
                 dict(
+                    id=f"{name}_id",
                     name=name,
                     created=0,
                     sets=[dict(path=f"{name}.gcode", count=1, remaining=1)],
@@ -288,7 +286,7 @@ class TestMultiDriverLANQueue(unittest.TestCase):
                 lq.ns, lq.addr, MagicMock(), logging.getLogger("lantestbase")
             )
             lq.lan.q.locks = LocalLockManager(self.locks, f"peer{i}")
-            lq.lan.q.jobs = LocalJobDict()
+            lq.lan.q.jobs = TestReplDict(lambda a, b: None)
             lq.lan.q.peers = self.peers
             if i > 0:
                 lq.lan.q.peers = self.peers[0][2].lan.q.peers
@@ -304,6 +302,7 @@ class TestMultiDriverLANQueue(unittest.TestCase):
             lq1.lan.q.setJob(
                 f"{name}_hash",
                 dict(
+                    id=f"{name}_hash",
                     name=name,
                     created=0,
                     sets=[

--- a/continuousprint/queues/abstract.py
+++ b/continuousprint/queues/abstract.py
@@ -84,6 +84,7 @@ class AbstractEditableQueue(AbstractQueue):
 
     @abstractmethod
     def import_job_from_view(self, job_view):
+        """Imports a JobView into storage. Returns ID of the imported job"""
         pass
 
 

--- a/continuousprint/queues/abstract.py
+++ b/continuousprint/queues/abstract.py
@@ -67,29 +67,8 @@ class AbstractQueue(ABC):
         pass
 
 
-class AbstractJobQueue(AbstractQueue):
-    """LAN queues (potentially others in the future) act on whole jobs and do not allow
-    edits to inner data"""
-
-    @abstractmethod
-    def submit_job(self, j: JobView) -> bool:
-        pass
-
-
 class AbstractEditableQueue(AbstractQueue):
-    """Some queues (e.g. local to a single printer) are directly editable."""
-
-    @abstractmethod
-    def add_job(self, name="") -> JobView:
-        pass
-
-    @abstractmethod
-    def add_set(self, job_id, data) -> SetView:
-        pass
-
-    @abstractmethod
-    def mv_set(self, set_id, after_id, dest_job) -> SetView:
-        pass
+    """Use for queues that are directly editable."""
 
     @abstractmethod
     def mv_job(self, job_id, after_id):
@@ -100,7 +79,23 @@ class AbstractEditableQueue(AbstractQueue):
         pass
 
     @abstractmethod
-    def rm_multi(self, job_ids, set_ids) -> dict:
+    def get_job_view(self, job_id):
+        pass
+
+    @abstractmethod
+    def import_job_from_view(self, job_view):
+        pass
+
+
+class AbstractFactoryQueue(AbstractEditableQueue):
+    """Use for queues where you can construct new jobs/sets"""
+
+    @abstractmethod
+    def add_job(self, name="") -> JobView:
+        pass
+
+    @abstractmethod
+    def add_set(self, job_id, data) -> SetView:
         pass
 
     @abstractmethod

--- a/continuousprint/queues/abstract_test.py
+++ b/continuousprint/queues/abstract_test.py
@@ -102,8 +102,19 @@ class EditableQueueTests(JobEqualityTests):
         jids = [j["id"] for j in self.q.as_dict()["jobs"]]
         self.assertEqual(jids, [self.jids[i] for i in (0, 2, 1, 3)])
 
+    def test_mv_to_front(self):
+        self.q.mv_job(self.jids[2], None)
+        jids = [j["id"] for j in self.q.as_dict()["jobs"]]
+        self.assertEqual(jids, [self.jids[i] for i in (2, 0, 1, 3)])
+
+    def test_mv_to_back(self):
+        self.q.mv_job(self.jids[2], self.jids[3])
+        jids = [j["id"] for j in self.q.as_dict()["jobs"]]
+        self.assertEqual(jids, [self.jids[i] for i in (0, 1, 3, 2)])
+
     def test_edit_job(self):
-        self.q.edit_job(self.jids[0], dict(draft=True))
+        result = self.q.edit_job(self.jids[0], dict(draft=True))
+        self.assertEqual(result, self.q.as_dict()["jobs"][0])
         self.assertEqual(self.q.as_dict()["jobs"][0]["draft"], True)
 
     def test_get_job_view(self):

--- a/continuousprint/queues/abstract_test.py
+++ b/continuousprint/queues/abstract_test.py
@@ -1,0 +1,119 @@
+from ..storage.database import JobView, SetView
+
+
+class DummyQueue:
+    name = "foo"
+
+
+def testJob(inst):
+    s = SetView()
+    s.id = inst
+    s.path = f"set{inst}.gcode"
+    s.count = 2
+    s.remaining = 2
+    s.rank = 0
+    s.sd = False
+    s.material_keys = ""
+    s.profile_keys = "profile"
+    s.completed = 0
+    s.save = lambda: True
+    j = JobView()
+    s.job = j
+    j.id = inst
+    j.acquired = False
+    j.name = f"job{inst}"
+    j.count = 2
+    j.remaining = 2
+    j.sets = [s]
+    j.draft = False
+    j.rank = 0
+    j.queue = DummyQueue()
+    j.created = 5
+    j.save = lambda: True
+    return j
+
+
+class JobEqualityTests:
+    def _strip(self, d, ks):
+        for k in ks:
+            del d[k]
+
+    def assertJobsEqual(self, v1, v2, ignore=[]):
+        d1 = v1.as_dict()
+        d2 = v2.as_dict()
+        for d in (d1, d2):
+            self._strip(d, [*ignore, "id", "queue"])
+        for s in d1["sets"]:
+            self._strip(s, ("id", "rank"))
+        for s in d2["sets"]:
+            self._strip(s, ("id", "rank"))
+        self.assertEqual(d1, d2)
+
+    def assertSetsEqual(self, s1, s2):
+        d1 = s1.as_dict()
+        d2 = s2.as_dict()
+        for d in (d1, d2):
+            self._strip(d, ("id", "rank"))
+        self.assertEqual(d1, d2)
+
+
+class AbstractQueueTests(JobEqualityTests):
+    def setUp(self):
+        raise NotImplementedError("Must create queue as self.q with testJob() inserted")
+
+    def test_acquire_get_release(self):
+        j = testJob(0)
+        self.assertEqual(self.q.acquire(), True)
+        self.assertEqual(self.q.get_job().acquired, True)
+        self.assertJobsEqual(self.q.get_job(), j, ignore=["acquired"])
+        self.assertSetsEqual(self.q.get_set(), j.sets[0])
+        self.q.release()
+        self.assertEqual(self.q.get_job(), None)
+        self.assertEqual(self.q.get_set(), None)
+
+    def test_decrement_and_reset(self):
+        self.assertEqual(self.q.acquire(), True)
+        self.assertEqual(self.q.decrement(), True)  # Work remains
+        self.assertEqual(self.q.get_set().remaining, 1)
+        self.q.reset_jobs([self.jid])
+        self.assertEqual(self.q.as_dict()["jobs"][0]["sets"][0]["remaining"], 2)
+
+    def test_remove_jobs(self):
+        self.assertEqual(self.q.remove_jobs([self.jid])["jobs_deleted"], 1)
+        self.assertEqual(len(self.q.as_dict()["jobs"]), 0)
+
+    def test_as_dict(self):
+        d = self.q.as_dict()
+        self.assertNotEqual(d.get("name"), None)
+        self.assertNotEqual(d.get("jobs"), None)
+        self.assertNotEqual(d.get("strategy"), None)
+
+
+class EditableQueueTests(JobEqualityTests):
+    NUM_TEST_JOBS = 4
+
+    def setUp(self):
+        raise NotImplementedError(
+            "Must create queue as self.q with testJob() inserted (inst=0..3)"
+        )
+
+    def test_mv_job_exchange(self):
+        self.q.mv_job(self.jids[1], self.jids[2])
+        jids = [j["id"] for j in self.q.as_dict()["jobs"]]
+        self.assertEqual(jids, [self.jids[i] for i in (0, 2, 1, 3)])
+
+    def test_edit_job(self):
+        self.q.edit_job(self.jids[0], dict(draft=True))
+        self.assertEqual(self.q.as_dict()["jobs"][0]["draft"], True)
+
+    def test_get_job_view(self):
+        self.assertJobsEqual(self.q.get_job_view(self.jids[0]), testJob(0))
+
+    def test_import_job_from_view(self):
+        j = testJob(10)
+        jid = self.q.import_job_from_view(j)
+        self.assertJobsEqual(self.q.get_job_view(jid), j)
+
+
+class AbstractFactoryQueueTests(JobEqualityTests):
+    pass  # TODO

--- a/continuousprint/queues/lan_test.py
+++ b/continuousprint/queues/lan_test.py
@@ -9,7 +9,7 @@ from .abstract_test import (
     EditableQueueTests,
     testJob as makeAbstractTestJob,
 )
-from .lan import LANQueue
+from .lan import LANQueue, ValidationError
 from ..storage.database import JobView, SetView
 from peerprint.lan_queue_test import LANQueueLocalTest as PeerPrintLANTest
 
@@ -60,11 +60,16 @@ class TestLANQueueNoConnection(LANQueueTest):
         self.q.update_peer_state("HI", {}, {}, {})  # No explosions? Good
 
 
+class DummyQueue:
+    name = "lantest"
+
+
 class TestLANQueueConnected(LANQueueTest):
     def setUp(self):
         super().setUp()
         self.q.lan = MagicMock()
         self.q.lan.q = MagicMock()
+        self.q.lan.q.hasJob.return_value = False  # For UUID generation
         self.q.lan.q.getPeers.return_value = {
             "a": dict(fs_addr="123", profile=dict(name="abc")),
         }
@@ -82,6 +87,7 @@ class TestLANQueueConnected(LANQueueTest):
         j = JobView()
         j.id = 1
         j.name = "j1"
+        j.queue = DummyQueue()
         s = SetView()
         s.path = path
         s.id = 2
@@ -100,57 +106,25 @@ class TestLANQueueConnected(LANQueueTest):
         j.acquired = False
         return j
 
-    def test_submit_job_file_missing(self):
+    def test_validation_file_missing(self):
         j = self._jbase()
         j.sets[0].profile_keys = "def,abc"
-        result = self.q.submit_job(j)
-        self.assertRegex(str(result), "file not found")
+        self.q._path_exists = lambda p: False  # Override path check for validation
+        with self.assertRaisesRegex(ValidationError, "file not found"):
+            self.q.import_job_from_view(j)
         self.fs.post.assert_not_called()
 
-    def test_submit_job_no_profile(self):
-        result = self.q.submit_job(self._jbase())
-        self.assertRegex(str(result), "no assigned profile")
+    def test_validation_no_profile(self):
+        with self.assertRaisesRegex(ValidationError, "no assigned profile"):
+            self.q.import_job_from_view(self._jbase())
         self.fs.post.assert_not_called()
 
-    def test_submit_job_no_match(self):
+    def test_validation_no_match(self):
         j = self._jbase()
         j.sets[0].profile_keys = "def"
-        result = self.q.submit_job(j)
-        self.assertRegex(str(result), "no match for set")
+        with self.assertRaisesRegex(ValidationError, "no match for set"):
+            self.q.import_job_from_view(j)
         self.fs.post.assert_not_called()
-
-    def test_submit_job(self):
-        with tempfile.NamedTemporaryFile(suffix=".gcode") as f:
-            self.fs.post.return_value = "hash"
-            j = self._jbase(f.name)
-            j.sets[0].profile_keys = "def,abc"
-            self.q.submit_job(j)
-            self.fs.post.assert_called()
-            self.q.lan.q.setJob.assert_called_with(
-                "hash",
-                {
-                    "name": "j1",
-                    "count": 1,
-                    "draft": False,
-                    "sets": [
-                        {
-                            "path": f.name,
-                            "count": 1,
-                            "materials": [],
-                            "profiles": ["def", "abc"],
-                            "id": 2,
-                            "rank": 1,
-                            "sd": False,
-                            "remaining": 1,
-                            "completed": 0,
-                        }
-                    ],
-                    "created": 100,
-                    "id": 1,
-                    "remaining": 1,
-                    "acquired": False,
-                },
-            )
 
 
 class TestLANQueueWithJob(LANQueueTest):

--- a/continuousprint/queues/local.py
+++ b/continuousprint/queues/local.py
@@ -69,12 +69,9 @@ class LocalQueue(AbstractFactoryQueue):
             return False
 
         has_work = self.set.decrement(self._profile) is not None
-        print(">>>>>>>>>>>>>> has_work", has_work)
         earliest_job = self.queries.getNextJobInQueue(
             self.ns, self._profile, self._set_path_exists
         )
-        print(">>>>>>>>>>>> earliest_job", earliest_job)
-        print("vs", self.job, "acquired", self.job.acquired)
         if has_work and earliest_job == self.job and self.job.acquired:
             self.set = self.job.next_set(self._profile, self._set_path_exists)
             return True

--- a/continuousprint/queues/local.py
+++ b/continuousprint/queues/local.py
@@ -52,7 +52,7 @@ class LocalQueue(AbstractFactoryQueue):
             self.ns, self._profile, self._set_path_exists
         )
         if p is not None and self.queries.acquireJob(p):
-            self.job = p
+            self.job = self.queries.getJob(p.id)  # Refetch job to get acquired state
             self.set = p.next_set(self._profile, self._set_path_exists)
             return True
         return False
@@ -69,9 +69,12 @@ class LocalQueue(AbstractFactoryQueue):
             return False
 
         has_work = self.set.decrement(self._profile) is not None
+        print(">>>>>>>>>>>>>> has_work", has_work)
         earliest_job = self.queries.getNextJobInQueue(
             self.ns, self._profile, self._set_path_exists
         )
+        print(">>>>>>>>>>>> earliest_job", earliest_job)
+        print("vs", self.job, "acquired", self.job.acquired)
         if has_work and earliest_job == self.job and self.job.acquired:
             self.set = self.job.next_set(self._profile, self._set_path_exists)
             return True
@@ -115,7 +118,7 @@ class LocalQueue(AbstractFactoryQueue):
         # TODO make transaction, move to storage/queries.py
         j = self.add_job()
         for (k, v) in manifest.items():
-            if k in ("peer_", "sets", "id", "acquired"):
+            if k in ("peer_", "sets", "id", "acquired", "queue"):
                 continue
             setattr(j, k, v)
         j.save()

--- a/continuousprint/queues/local_test.py
+++ b/continuousprint/queues/local_test.py
@@ -115,6 +115,8 @@ class TestLocalQueueInOrderInitial(unittest.TestCase):
         )
 
 
+# TODO test mv_job
+
 # TODO test SD card behavior on importing/exporting and printing
 # class TestSD(unittest.TestCase):
 #    def testSDExport(self):

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -186,7 +186,7 @@
   padding: 2px;
   border: 1px transparent solid;
 }
-#tab_plugin_continuousprint .loading {
+#tab_plugin_continuousprint .cp-queue .loading {
   opacity: 0.3;
   cursor: default !important;
 }
@@ -422,44 +422,3 @@
 
 #tab_plugin_continuousprint .header > *, #tab_plugin_continuousprint .entries > .entry > * {
   flex: 1;
-  text-align: center;
-}
-
-#tab_plugin_continuousprint .timelapse_thumbnail {
-	position: relative;
-	display: inline-block;
-}
-
-#tab_plugin_continuousprint .timelapse_thumbnail > img {
-	display: none;
-	cursor: pointer;
-	position: absolute;
-	z-index: 1000;
-	top: 0;
-	max-width: 100px;
-	left: 18px;
-	border: 1px black solid;
-	padding: 5px;
-	background-color: white;
-}
-#tab_plugin_continuousprint .timelapse_thumbnail > i {
-	padding: 2px; /* So hover is maintained when mousing over to image */
-}
-#tab_plugin_continuousprint .timelapse_thumbnail:hover > img {
-  display: block;
-}
-
-#tab_plugin_continuousprint .separator {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-#tab_plugin_continuousprint .separator .line {
-  content: '';
-  flex: 1;
-  border-bottom: 1px solid #000;
-  margin-left: 5px;
-  margin-right: 5px;
-}
-
-/* ======== */

--- a/continuousprint/static/js/continuousprint_job.js
+++ b/continuousprint/static/js/continuousprint_job.js
@@ -20,7 +20,7 @@ function CPJob(obj, peers, api, profile) {
   }
   var self = this;
 
-  obj = {...{sets: [], name: "", draft: false, count: 1, queue: "default", id: -1}, ...obj};
+  obj = {...{sets: [], name: "", draft: false, count: 1, id: -1}, ...obj};
   if (obj.remaining === undefined) {
     obj.remaining = obj.count;
   }
@@ -82,7 +82,7 @@ function CPJob(obj, peers, api, profile) {
   }
 
   self.editStart = function() {
-    api.edit(api.JOB, {id: self.id(), draft: true}, () => {
+    api.edit(api.JOB, {queue: obj.queue, id: self.id(), draft: true}, () => {
       self.draft(true);
     });
   }
@@ -96,7 +96,7 @@ function CPJob(obj, peers, api, profile) {
     self.sets.push(newqs);
  }
   self.editCancel = function() {
-    api.edit(api.JOB, {id: self.id(), draft: false}, self._update);
+    api.edit(api.JOB, {queue: obj.queue, id: self.id(), draft: false}, self._update);
   }
   self.onBlur = function(vm, e) {
     let cl = e.target.classList;
@@ -109,6 +109,7 @@ function CPJob(obj, peers, api, profile) {
   self.editEnd = function() {
     let data = self.as_object();
     data.draft = false;
+    data.queue = obj.queue;
     api.edit(api.JOB, data, self._update);
   }
 

--- a/continuousprint/static/js/continuousprint_queue.js
+++ b/continuousprint/static/js/continuousprint_queue.js
@@ -31,6 +31,7 @@ function CPQueue(data, api, files, profile) {
     self.shiftsel = ko.observable(-1);
     self.details = ko.observable("");
     self.fullDetails = ko.observable("");
+    self.ready = ko.observable(data.name === 'local' || Object.keys(data.peers).length > 0);
     if (self.addr !== null && data.peers !== undefined) {
       let pkeys = Object.keys(data.peers);
       if (pkeys.length === 0) {
@@ -291,7 +292,7 @@ function CPQueue(data, api, files, profile) {
         set_data['job'] = null;
         // Invoking API causes a new job to be created
         self.api.add(self.api.SET, set_data, (response) => {
-          return self._pushJob({id: response.job_id, name: set_data['jobName'], draft: true, count: 1, sets: [response.set_]});
+          return self._pushJob({queue: self.name, id: response.job_id, name: set_data['jobName'], draft: true, count: 1, sets: [response.set_]});
         });
     };
 

--- a/continuousprint/static/js/continuousprint_queue.js
+++ b/continuousprint/static/js/continuousprint_queue.js
@@ -253,6 +253,15 @@ function CPQueue(data, api, files, profile) {
       });
     }
 
+    self.hasDraftJobs = function() {
+      for (let j of self.jobs()) {
+        if (j.draft()) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     self.addFile = function(data, infer_profile=false) {
         if (data.path.endsWith('.gjob')) {
           // .gjob import has a different API path

--- a/continuousprint/static/js/continuousprint_queue.test.js
+++ b/continuousprint/static/js/continuousprint_queue.test.js
@@ -33,7 +33,9 @@ function items(njobs = 1, nsets = 2) {
 }
 
 function init(njobs = 1) {
-  return new VM({name:"test", jobs:items(njobs)}, mocks());
+  return new VM({name:"test", jobs:items(njobs), peers:[
+    {name: "localhost", profile: {name: "profile"}, status: "IDLE"}
+  ]}, mocks());
 }
 
 test('newEmptyJob', () => {

--- a/continuousprint/static/js/continuousprint_viewmodel.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.js
@@ -256,6 +256,10 @@ function CPViewModel(parameters) {
       if (evt.from.id === "queue_sets" && !evt.to.classList.contains("draft")) {
         return false;
       }
+      // No dragging items in non-ready queues
+      if (evt.to.classList.contains("loading")) {
+        return false;
+      }
       return true;
     };
 

--- a/continuousprint/static/js/continuousprint_viewmodel.test.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.test.js
@@ -159,12 +159,12 @@ test('sortEnd job to start', () => {
   expect(data.after_id).toEqual(-1);
 });
 
-test('sortEnd job to end', () => {
+test.only('sortEnd job to end', () => {
   let v = init(njobs=2);
   let ccont = {classList: {contains: () => true}};
   let evt = {from: ccont, to: ccont};
   let j = v.defaultQueue.jobs()[1];
-  v.sortEnd(evt, j, null);
+  v.sortEnd(evt, j, v.defaultQueue, dataFor=function(elem) {return v.defaultQueue});
   expect(v.files.onServerConnect).toHaveBeenCalled();
   expect(v.api.mv).toHaveBeenCalled();
   let data = v.api.mv.mock.calls[0][1];

--- a/continuousprint/storage/database.py
+++ b/continuousprint/storage/database.py
@@ -113,6 +113,7 @@ class JobView:
         sets.sort(key=lambda s: s.rank)
         sets = [s.as_dict() for s in sets]
         d = dict(
+            queue=self.queue.name,
             name=self.name,
             count=self.count,
             draft=self.draft,
@@ -338,7 +339,6 @@ def init(db_path="queues.sqlite3", logger=None):
                         for f in Set._meta.sorted_field_names:
                             attrs[f] = getattr(s, f)
                         attrs["completed"] = max(0, attrs["count"] - attrs["remaining"])
-                        print(attrs)
                         TempSet.create(**attrs)
                         if logger is not None:
                             logger.warning(f"Migrating set {s.path} to schema v0.0.3")

--- a/continuousprint/storage/lan.py
+++ b/continuousprint/storage/lan.py
@@ -17,8 +17,8 @@ class LANJobView(JobView):
         self.id = manifest["id"]
         self.peer = manifest["peer_"]
         self.sets = []
-        self.draft = False
-        self.acquired = None
+        self.draft = manifest.get("draft", False)
+        self.acquired = manifest.get("acquired", False)
         self.sets = [LANSetView(s, self, i) for i, s in enumerate(manifest["sets"])]
 
     def save(self):

--- a/continuousprint/storage/lan.py
+++ b/continuousprint/storage/lan.py
@@ -1,4 +1,5 @@
 from .database import JobView, SetView
+from .queries import getint
 from requests.exceptions import HTTPError
 
 
@@ -8,19 +9,12 @@ class LANQueueView:
         self.name = lq.ns
 
 
-def _getint(d, k, default=0):
-    v = d.get(k, default)
-    if type(v) == str:
-        v = int(v)
-    return v
-
-
 class LANJobView(JobView):
     def __init__(self, manifest, lq):
         self.name = manifest.get("name", "")
-        self.created = _getint(manifest, "created")
-        self.count = _getint(manifest, "count")
-        self.remaining = _getint(manifest, "remaining", default=self.count)
+        self.created = getint(manifest, "created")
+        self.count = getint(manifest, "count")
+        self.remaining = getint(manifest, "remaining", default=self.count)
         self.queue = LANQueueView(lq)
         self.id = manifest["id"]
         self.peer = manifest["peer_"]
@@ -54,8 +48,8 @@ class LANSetView(SetView):
         self.id = f"{job.id}_{rank}"
         for attr in ("path", "count"):
             setattr(self, attr, data[attr])
-        self.remaining = _getint(data, "remaining", default=self.count)
-        self.completed = _getint(data, "completed")
+        self.remaining = getint(data, "remaining", default=self.count)
+        self.completed = getint(data, "completed")
         self.material_keys = ",".join(data.get("materials", []))
         self.profile_keys = ",".join(data.get("profiles", []))
         self._resolved = None

--- a/continuousprint/storage/lan.py
+++ b/continuousprint/storage/lan.py
@@ -8,18 +8,30 @@ class LANQueueView:
         self.name = lq.ns
 
 
+def _getint(d, k, default=0):
+    v = d.get(k, default)
+    if type(v) == str:
+        v = int(v)
+    return v
+
+
 class LANJobView(JobView):
     def __init__(self, manifest, lq):
-        for attr in ("name", "count", "created"):
-            setattr(self, attr, manifest[attr])
-        self.remaining = manifest.get("remaining", self.count)
+        self.name = manifest.get("name", "")
+        self.created = _getint(manifest, "created")
+        self.count = _getint(manifest, "count")
+        self.remaining = _getint(manifest, "remaining", default=self.count)
         self.queue = LANQueueView(lq)
         self.id = manifest["id"]
         self.peer = manifest["peer_"]
         self.sets = []
         self.draft = manifest.get("draft", False)
         self.acquired = manifest.get("acquired", False)
-        self.sets = [LANSetView(s, self, i) for i, s in enumerate(manifest["sets"])]
+        self.updateSets(manifest["sets"])
+        self.hash = manifest.get("hash")
+
+    def updateSets(self, sets_list):
+        self.sets = [LANSetView(s, self, i) for i, s in enumerate(sets_list)]
 
     def save(self):
         self.queue.lq.set_job(self.id, self.as_dict())
@@ -38,12 +50,12 @@ class LANSetView(SetView):
     def __init__(self, data, job, rank):
         self.job = job
         self.sd = False
-        self.rank = rank
+        self.rank = int(rank)
         self.id = f"{job.id}_{rank}"
         for attr in ("path", "count"):
             setattr(self, attr, data[attr])
-        self.remaining = data.get("remaining", self.count)
-        self.completed = data.get("completed", 0)
+        self.remaining = _getint(data, "remaining", default=self.count)
+        self.completed = _getint(data, "completed")
         self.material_keys = ",".join(data.get("materials", []))
         self.profile_keys = ",".join(data.get("profiles", []))
         self._resolved = None
@@ -52,7 +64,7 @@ class LANSetView(SetView):
         if self._resolved is None:
             try:
                 self._resolved = self.job.queue.lq.resolve_set(
-                    self.job.peer, self.job.id, self.path
+                    self.job.peer, self.job.hash, self.path
                 )
             except HTTPError as e:
                 raise ResolveError(f"Failed to resolve {self.path}") from e

--- a/continuousprint/storage/queries.py
+++ b/continuousprint/storage/queries.py
@@ -274,17 +274,6 @@ def moveJob(src_id: int, dest_id: int):
     return _moveImpl(Job, j, dest_id)
 
 
-def moveSet(src_id: int, dest_id: int, dest_job: int):
-    s = Set.get(id=src_id)
-    if dest_job == -1:
-        j = newEmptyJob(s.job.queue)
-    else:
-        j = Job.get(id=dest_job)
-    s.job = j
-    s.save()
-    _moveImpl(Set, s, dest_id)
-
-
 def newEmptyJob(q, name="", rank=_rankEnd):
     if type(q) == str:
         q = Queue.get(name=q)

--- a/continuousprint/storage/queries.py
+++ b/continuousprint/storage/queries.py
@@ -188,6 +188,7 @@ def updateJob(job_id, data, queue=DEFAULT_QUEUE):
             if k in (
                 "id",
                 "sets",
+                "queue",
             ):  # ignored or handled separately
                 continue
 
@@ -234,10 +235,11 @@ def _rankEnd():
     return time.time()
 
 
-def _moveImpl(cls, src, dest_id: int, retried=False):
-    if dest_id == -1:
+def _moveImpl(cls, src, dest_id, retried=False):
+    if dest_id is None:
         destRank = 0
     else:
+        dest_id = int(dest_id)
         destRank = cls.get(id=dest_id).rank
 
     # Get the next object having a rank beyond the destination rank,

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -300,22 +300,6 @@ class TestMultiItemQueue(DBTest):
                 q.moveJob(*moveArgs)
                 self.assertEqual([j.id for j in q.getJobsAndSets(DEFAULT_QUEUE)], want)
 
-    def testMoveSet(self):
-        for (desc, moveArgs, want) in [
-            ("FirstToLast", (1, 2, 1), [2, 1, 3, 4]),
-            ("LastToFirst", (2, -1, 1), [2, 1, 3, 4]),
-            ("DiffJob", (1, 3, 2), [2, 3, 1, 4]),
-            ("NewJob", (1, -1, -1), [2, 3, 4, 1]),
-        ]:
-            with self.subTest(f"{desc}: moveSet({moveArgs})"):
-                q.moveSet(*moveArgs)
-                set_order = [
-                    (s["id"], s["rank"])
-                    for j in q.getJobsAndSets(DEFAULT_QUEUE)
-                    for s in j.as_dict()["sets"]
-                ]
-                self.assertEqual(set_order, [(w, ANY) for w in want])
-
     def testGetNextJobAfterDecrement(self):
         j = q.getNextJobInQueue(DEFAULT_QUEUE, PROFILE)
         s = j.sets[0]

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -219,12 +219,14 @@ class TestSingleItemQueue(DBTest):
         j = Job.get(id=1)
         s = j.sets[0]
         s.remaining = 0
+        s.completed = 3
         j.remaining = 0
         s.save()
         j.save()
         q.resetJobs([j.id])
         # Replenishing the job replenishes all sets
         self.assertEqual(Set.get(id=s.id).remaining, 1)
+        self.assertEqual(Set.get(id=s.id).completed, 0)
         self.assertEqual(Job.get(id=j.id).remaining, 1)
 
     def testUpdateJobCount(self):
@@ -295,7 +297,7 @@ class TestMultiItemQueue(DBTest):
             )
 
     def testMoveJob(self):
-        for (moveArgs, want) in [((1, 2), [2, 1]), ((2, -1), [2, 1])]:
+        for (moveArgs, want) in [((1, 2), [2, 1]), ((2, None), [2, 1])]:
             with self.subTest(f"moveJob({moveArgs}) -> want {want}"):
                 q.moveJob(*moveArgs)
                 self.assertEqual([j.id for j in q.getJobsAndSets(DEFAULT_QUEUE)], want)

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -1,31 +1,3 @@
-<div id="cpq_submitDialog" class="modal hide fade">
-    <div class="modal-header">
-    <img src="plugin/continuousprint/static/img/CPQ.svg" alt="Continuous Print" style="height: 60px;" class="cpq_logo">
-    <h2 class="modal-title" data-bind="text:jobSendTitle"></h2>
-    </div>
-    <div class="modal-body">
-      <div class="alert">
-        <p>
-        <i class="fas fa-exclamation-triangle"></i>
-          The job's progress will be reset, and it cannot be edited or transferred once submitted (only deleted).
-        </p>
-      </div>
-      <div class="alert">
-        <p>
-        <i class="fas fa-exclamation-triangle"></i>
-          It is your responsibility to ensure that the job you send is compatible with <strong>all</strong>
-          printers connected to the destination queue.
-        </p>
-        <p>
-          <strong>Failure to do so may cause damage to your printers.</strong>
-        </p>
-      </div>
-    </div>
-    <div class="modal-footer">
-        <button class="btn btn-cancel" data-dismiss="modal" aria-hidden="true">Cancel</button>
-        <button class="btn btn-danger btn-confirm" data-bind="click: submitJob">Confirm</button>
-    </div>
-</div>
 <div id="cpq_removeConfirmDialog" class="modal hide fade">
     <div class="modal-header">
       <a href="https://smartin015.github.io/continuousprint/"><img src="plugin/continuousprint/static/img/CPQ.svg" alt="Continuous Print" style="height: 60px;" class="cpq_logo"></a>
@@ -174,7 +146,7 @@
           <!-- /ko -->
           <div class="accordion-heading job-header">
             <div class="queue-row-container">
-            <i class="fas fa-grip-vertical" data-bind="style: {visibility: (draft() || queue.name !== 'local') ? 'hidden' : null}"></i>
+            <i class="fas fa-grip-vertical"></i>
               <i style="cursor: pointer" data-bind="hidden: draft() || (acquiredBy() && $root.active()), css: selected() ? 'fas fa-check-square' : 'far fa-square', event: {mousedown: queue.onChecked}"></i>
               <i data-bind="visible: acquiredBy(), attr: {title: 'Printer: ' + acquiredBy()}" class="fas fa-cube"></i>
               <!-- ko if: draft -->

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -74,7 +74,7 @@
   </div>
 
   <div id="continuousprint_tab_queues" class="tab-pane active" data-bind="foreach: {data: queues, as: 'queue'}">
-    <div class="cp-queue">
+    <div class="cp-queue" data-bind="css: {'loading': $root.loading() || !ready()}">
     <div class="cp-header action-bar">
         <div class="multiselect">
           <div class="dropdown">
@@ -96,14 +96,12 @@
             <button class="btn" data-bind="visible: checkFraction() > 0, click: deleteSelected" title="Delete selected">
               <i style="cursor: pointer" class="far fa-trash-alt"></i>
             </button>
-            <!-- ko if: name === 'local' -->
             <button class="btn" data-bind="visible: checkFraction() > 0, click: resetSelected" title="Reset selected progress">
               <i style="cursor: pointer" class="fas fa-redo"></i>
-              </button>
+            </button>
             <button class="btn" data-bind="visible: checkFraction() > 0, click: exportSelected" title="Save .gjob to files list">
               <i style="cursor: pointer" class="far fa-save"></i>
             </button>
-            <!-- /ko -->
           </div>
           <div class="dropdown" style="z-index:1;">
             <a class="btn dropdown-toggle" data-toggle="dropdown">
@@ -135,11 +133,11 @@
         Hint: click New Job above or the <i class="fas fa-plus"></i> next to a file to add it to the queue.
         </div>
         <div class="hint" data-bind="visible: jobs().length == 0 && name !== 'local'">
-          Hint: drag a job here from the local queue to submit it to printers on the network.
+          Hint: drag a job here from the local queue to send it to printers on the network.
         </div>
-        <div data-bind="cpsortable: {foreach: jobs, as: 'job', options: {handle: '.fa-grip-vertical', onStart: $root.sortStart, onEnd: $root.sortEnd, onMove: $root.sortMove}}, css: {'loading': $root.loading(), 'local': name === 'local', 'highlight': $root.draggingJob}" style="width: 100%">
+        <div data-bind="cpsortable: {foreach: jobs, as: 'job', options: {handle: '.fa-grip-vertical', onStart: $root.sortStart, onEnd: $root.sortEnd, onMove: $root.sortMove}}, css: {'loading': $root.loading() || !ready(), 'local': name === 'local', 'highlight': $root.draggingJob() && ready()}" style="width: 100%">
         <div class="accordion-group job" data-bind="css: {acquired: acquiredBy() !== undefined, draft: draft, shiftsel: queue.shiftsel() === $index()}">
-          <!-- ko if: !draft() && queue.name === 'local' -->
+          <!-- ko if: !draft() -->
           <div class="btn floatedit btn-primary" data-bind="click: editStart" style="cursor: pointer">
               <i class="fas fa-edit"></i>
           </div>
@@ -182,7 +180,7 @@
                   <div class="total has_title" title="Total number of prints yet to be printed across all remaining iterations of the job">Pending<sup>?</sup></div>
                 </div>
               <!-- /ko -->
-              <div id="queue_sets" data-bind="cpsortable: {foreach: sets, as: 'set', options: {handle: '.fa-grip-vertical', onStart: $root.sortStart, onEnd: $root.sortEnd, onMove: $root.sortMove, group: 'sets'}}, css: {'empty': sets().length < 1, 'draft': job.draft, 'highlight': $root.draggingSet() && job.draft()}" class="sets">
+              <div id="queue_sets" data-bind="cpsortable: {foreach: sets, as: 'set', options: {handle: '.fa-grip-vertical', onStart: $root.sortStart, onEnd: $root.sortEnd, onMove: $root.sortMove, group: 'sets'}}, css: {'empty': sets().length < 1, 'draft': job.draft, 'highlight': $root.draggingSet() && job.draft() && queue.ready()}" class="sets">
                 <div class="accordion-group">
                   <div class="accordion-heading">
                     <div class="queue-row-container">

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -99,7 +99,7 @@
             <button class="btn" data-bind="visible: checkFraction() > 0, click: resetSelected" title="Reset selected progress">
               <i style="cursor: pointer" class="fas fa-redo"></i>
             </button>
-            <button class="btn" data-bind="visible: checkFraction() > 0, click: exportSelected" title="Save .gjob to files list">
+            <button class="btn" data-bind="visible: checkFraction() > 0 && name === 'local', click: exportSelected" title="Save .gjob to files list">
               <i style="cursor: pointer" class="far fa-save"></i>
             </button>
           </div>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,7 +95,8 @@ A couple of optional changes can improve your developer flow:
 Edit OctoPrint's yaml config to turn off minification and ignore startup errors (at `continuousprint/volume/config.yaml` in the Docker container, else in your OctoPrint install path):
 
 ```
-ignoreIncompleteStartup: true
+server:
+  ignoreIncompleteStartup: true
 devel:
   webassets:
     bundle: false

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/smartin015/continuousprint"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["peewee<4", "peerprint==0.0.8"]
+plugin_requires = ["peewee<4", "peerprint==0.1.0"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This PR aims to bring LAN queues to parity with the local queue (#101), allowing for:

* Reordering of LAN queue jobs after submission
* Editing of LAN queue jobs after submission
* Transfer from LAN queue back to local queue via drag & drop

* [ ] Before submission, ensure the next version of peerprint has been pushed to pypi (see https://github.com/smartin015/peerprint/pull/3).