### PR TITLE
Remove show/hide stats, fix bugs from exploratory testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM python:3.7
 
-# Installing ffmpeg is needed for working with timelapses - this can be ommitted otherwise
+# Installing ffmpeg is needed for working with timelapses - can be ommitted otherwise
 RUN apt-get update && apt-get -y install --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
+
+# IPFS installation for LAN filesharing
+RUN wget https://dist.ipfs.tech/kubo/v0.15.0/kubo_v0.15.0_linux-amd64.tar.gz \
+  && tar -xvzf kubo_v0.15.0_linux-amd64.tar.gz \
+  && cd kubo \
+  && bash -c ". ./install.sh" \
+  && ipfs --version
+
 
 RUN adduser oprint
 USER oprint

--- a/continuousprint/driver.py
+++ b/continuousprint/driver.py
@@ -160,6 +160,10 @@ class Driver:
         nxt = self._state_start_print(a, p)
         return nxt if nxt is not None else self._state_start_print
 
+    def _fmt_material_key(self, mk):
+        s = mk.split("_")
+        return f"{s[0]} ({s[1]})"
+
     def _state_start_print(self, a: Action, p: Printer):
         if p != Printer.IDLE:
             self._set_status("Waiting for printer to be ready")
@@ -177,7 +181,7 @@ class Driver:
             cur = self._cur_materials[i] if i < len(self._cur_materials) else None
             if im != cur:
                 self._set_status(
-                    f"Waiting for spool {im} in tool {i} (currently: {cur})",
+                    f"Need {self._fmt_material_key(im)} in tool {i}, but {self._fmt_material_key(cur)} is loaded",
                     StatusType.NEEDS_ACTION,
                 )
                 return

--- a/continuousprint/driver.py
+++ b/continuousprint/driver.py
@@ -37,7 +37,7 @@ def timeAgo(elapsed):
 
 class Driver:
     # If the printer is idle for this long while printing, break out of the printing state (consider it a failure)
-    PRINTING_IDLE_BREAKOUT_SEC = 10.0
+    PRINTING_IDLE_BREAKOUT_SEC = 15.0
 
     def __init__(
         self,
@@ -209,7 +209,13 @@ class Driver:
                     StatusType.NEEDS_ACTION,
                 )
                 return self._state_paused
-        elif a == Action.SUCCESS:
+        elif a == Action.SUCCESS or (
+            p == Printer.IDLE
+            and time.time() - self.idle_start_ts > self.PRINTING_IDLE_BREAKOUT_SEC
+        ):
+            # If idle state without event, assume we somehow missed the SUCCESS action.
+            # We wait for a period of idleness to prevent idle-before-success events
+            # from double-completing prints.
             item = self.q.get_set()
 
             # A limitation of `octoprint.printer`, the "current file" path passed to the driver is only
@@ -231,14 +237,6 @@ class Driver:
                 self._set_status("Waiting for printer to be ready")
         elif p == Printer.PAUSED:
             return self._state_paused
-        elif (
-            p == Printer.IDLE
-            and time.time() - self.idle_start_ts > self.PRINTING_IDLE_BREAKOUT_SEC
-        ):
-            # Idle state without event; assume we somehow missed the SUCCESS action
-            # We wait for a period of idleness to prevent idle-before-success events
-            # from double-completing prints.
-            return self._state_failure
 
     def _state_paused(self, a: Action, p: Printer):
         self._set_status("Paused", StatusType.NEEDS_ACTION)

--- a/continuousprint/driver.py
+++ b/continuousprint/driver.py
@@ -161,8 +161,13 @@ class Driver:
         return nxt if nxt is not None else self._state_start_print
 
     def _fmt_material_key(self, mk):
-        s = mk.split("_")
-        return f"{s[0]} ({s[1]})"
+        try:
+            s = mk.split("_")
+            return f"{s[0]} ({s[1]})"
+        except IndexError:
+            return mk
+        except AttributeError:
+            return mk
 
     def _state_start_print(self, a: Action, p: Printer):
         if p != Printer.IDLE:

--- a/continuousprint/driver.py
+++ b/continuousprint/driver.py
@@ -52,7 +52,9 @@ class Driver:
         self._set_status("Initializing")
         self.q = queue
         self.state = self._state_unknown
-        self.idle_start_ts = None
+        self.last_printer_state = None
+        self.printer_state_ts = 0
+        self.printer_state_logs_suppressed = False
         self.retries = 0
         self.retry_on_pause = False
         self.max_retries = 0
@@ -79,20 +81,20 @@ class Driver:
         # so the state is updated in a thread safe way.
         with self.mutex:
             now = time.time()
-            if self.idle_start_ts is None or self.idle_start_ts + 15 > now:
-                extra = (
-                    f"(idle logs hidden after {self.idle_start_ts+15})"
-                    if self.idle_start_ts is not None
-                    else ""
-                )
+            if self.printer_state_ts + 15 > now or a != Action.TICK:
                 self._logger.debug(
-                    f"{a.name}, {p.name}, path={path}, materials={materials}, bed_temp={bed_temp} {extra}"
+                    f"{a.name}, {p.name}, path={path}, materials={materials}, bed_temp={bed_temp}"
+                )
+            elif a == Action.TICK and not self.printer_state_logs_suppressed:
+                self.printer_state_logs_suppressed = True
+                self._logger.debug(
+                    f"suppressing further debug logs for action=TICK, printer state={p.name}"
                 )
 
-            if p == Printer.IDLE and self.idle_start_ts is None:
-                self.idle_start_ts = now
-            elif p != Printer.IDLE and self.idle_start_ts is not None:
-                self.idle_start_ts = None
+            if p != self.last_printer_state:
+                self.printer_state_ts = now
+                self.last_printer_state = p
+                self.printer_state_logs_suppressed = False
 
             if path is not None:
                 self._cur_path = path
@@ -195,6 +197,14 @@ class Driver:
                     StatusType.ERROR,
                 )
 
+    def _long_idle(self, p):
+        # We wait until we're in idle state for a long-ish period before acting, as
+        # IDLE can be returned as a state before another event-based action (e.g. SUCCESS)
+        return (
+            p == Printer.IDLE
+            and time.time() - self.printer_state_ts > self.PRINTING_IDLE_BREAKOUT_SEC
+        )
+
     def _state_printing(self, a: Action, p: Printer, elapsed=None):
         if a == Action.FAILURE:
             return self._state_failure
@@ -209,10 +219,7 @@ class Driver:
                     StatusType.NEEDS_ACTION,
                 )
                 return self._state_paused
-        elif a == Action.SUCCESS or (
-            p == Printer.IDLE
-            and time.time() - self.idle_start_ts > self.PRINTING_IDLE_BREAKOUT_SEC
-        ):
+        elif a == Action.SUCCESS or self._long_idle(p):
             # If idle state without event, assume we somehow missed the SUCCESS action.
             # We wait for a period of idleness to prevent idle-before-success events
             # from double-completing prints.
@@ -240,7 +247,7 @@ class Driver:
 
     def _state_paused(self, a: Action, p: Printer):
         self._set_status("Paused", StatusType.NEEDS_ACTION)
-        if p == Printer.IDLE:
+        if self._long_idle(p):
             # Here, IDLE implies the user cancelled the print.
             # Go inactive to prevent stomping on manual changes
             return self._state_inactive
@@ -323,7 +330,7 @@ class Driver:
             self._set_status("Error when clearing bed - aborting", StatusType.ERROR)
             return self._state_inactive  # Skip past failure state to inactive
 
-        if p == Printer.IDLE:  # Idle state without event; assume success
+        if self._long_idle(p):  # Idle state without event; assume success
             return self._enter_start_print(a, p)
         else:
             self._set_status("Clearing bed")
@@ -341,7 +348,7 @@ class Driver:
             return self._state_inactive
 
         # Idle state without event -> assume success and go idle
-        if a == Action.SUCCESS or p == Printer.IDLE:
+        if a == Action.SUCCESS or self._long_idle(p):
             return self._state_idle
 
         self._set_status("Finishing up")

--- a/continuousprint/driver_test.py
+++ b/continuousprint/driver_test.py
@@ -78,7 +78,7 @@ class TestFromInactive(unittest.TestCase):
         self.assertEqual(self.d.state.__name__, self.d._state_printing.__name__)
 
         # Continued idleness triggers bed clearing and such
-        self.d.idle_start_ts = time.time() - (Driver.PRINTING_IDLE_BREAKOUT_SEC + 1)
+        self.d.printer_state_ts = time.time() - (Driver.PRINTING_IDLE_BREAKOUT_SEC + 1)
         self.d.action(DA.TICK, DP.IDLE)
         self.assertEqual(self.d.state.__name__, self.d._state_start_clearing.__name__)
 
@@ -153,6 +153,7 @@ class TestFromInactive(unittest.TestCase):
         )  # -> success
         self.d.q.get_set_or_acquire.return_value = None  # Nothing more in the queue
         self.d.action(DA.TICK, DP.IDLE)  # -> start_finishing
+        self.d.printer_state_ts = time.time() - (Driver.PRINTING_IDLE_BREAKOUT_SEC + 1)
         self.d.action(DA.TICK, DP.IDLE)  # -> finishing
         self.d._runner.run_finish_script.assert_called()
         self.assertEqual(self.d.state.__name__, self.d._state_finishing.__name__)

--- a/continuousprint/driver_test.py
+++ b/continuousprint/driver_test.py
@@ -77,10 +77,10 @@ class TestFromInactive(unittest.TestCase):
         self.d.action(DA.TICK, DP.IDLE)
         self.assertEqual(self.d.state.__name__, self.d._state_printing.__name__)
 
-        # Continued idleness triggers failure (retry behavior validated in test_retry_after_failure)
+        # Continued idleness triggers bed clearing and such
         self.d.idle_start_ts = time.time() - (Driver.PRINTING_IDLE_BREAKOUT_SEC + 1)
         self.d.action(DA.TICK, DP.IDLE)
-        self.assertEqual(self.d.state.__name__, self.d._state_failure.__name__)
+        self.assertEqual(self.d.state.__name__, self.d._state_start_clearing.__name__)
 
     def test_retry_after_failure(self):
         self.d.state = self.d._state_failure

--- a/continuousprint/integration_test.py
+++ b/continuousprint/integration_test.py
@@ -62,7 +62,7 @@ class IntegrationTest(DBTest):
                 self.d.action(DA.TICK, DP.IDLE)  # -> clearing
                 self.d._runner.clear_bed.assert_called()
                 self.d._runner.clear_bed.reset_mock()
-                self.d.action(DA.TICK, DP.IDLE)  # -> start_print
+                self.d.action(DA.SUCCESS, DP.IDLE)  # -> start_print
             else:  # Finishing
                 self.d.action(DA.TICK, DP.IDLE)  # -> start_finishing
                 self.assertEqual(
@@ -71,7 +71,7 @@ class IntegrationTest(DBTest):
                 self.d.action(DA.TICK, DP.IDLE)  # -> finishing
                 self.d._runner.run_finish_script.assert_called()
                 self.d._runner.run_finish_script.reset_mock()
-                self.d.action(DA.TICK, DP.IDLE)  # -> inactive
+                self.d.action(DA.SUCCESS, DP.IDLE)  # -> inactive
                 self.assertEqual(self.d.state.__name__, self.d._state_idle.__name__)
         except AssertionError as e:
             raise AssertionError(
@@ -158,6 +158,7 @@ class TestLocalQueue(IntegrationTest):
         queries.updateJob(1, dict(draft=False))
 
         self.d.action(DA.ACTIVATE, DP.IDLE)  # -> start_print -> printing
+        self.assertEqual(self.d.state, self.d._state_printing)
         self.assert_from_printing_state("a.gcode")
         self.assert_from_printing_state("a.gcode")
         self.assert_from_printing_state("b.gcode", finishing=True)
@@ -333,7 +334,7 @@ class TestMultiDriverLANQueue(unittest.TestCase):
             d1.action(DA.SUCCESS, DP.IDLE, path="j1.gcode")  # -> success
             d1.action(DA.TICK, DP.IDLE)  # -> start_clearing
             d1.action(DA.TICK, DP.IDLE)  # -> clearing
-            d1.action(DA.TICK, DP.IDLE)  # -> start_print
+            d1.action(DA.SUCCESS, DP.IDLE)  # -> start_print
             self.assertEqual(d1._runner.start_print.call_args[0][0].path, "j3.gcode")
             self.assertEqual(self.locks["j3_hash"], "peer0")
             d1._runner.start_print.reset_mock()
@@ -343,7 +344,7 @@ class TestMultiDriverLANQueue(unittest.TestCase):
             d2.action(DA.SUCCESS, DP.IDLE, path="j2.gcode")  # -> success
             d2.action(DA.TICK, DP.IDLE)  # -> start_finishing
             d2.action(DA.TICK, DP.IDLE)  # -> finishing
-            d2.action(DA.TICK, DP.IDLE)  # -> idle
+            d2.action(DA.SUCCESS, DP.IDLE)  # -> idle
             self.assertEqual(d2.state.__name__, d2._state_idle.__name__)
 
 

--- a/continuousprint/queues/local.py
+++ b/continuousprint/queues/local.py
@@ -144,7 +144,8 @@ class LocalQueue(AbstractFactoryQueue):
         out_dir = str(Path(gjob_path).stem)
         self._mkdir(out_dir)
         manifest, filepaths = unpack_job(
-            self._path_on_disk(gjob_path), self._path_on_disk(out_dir)
+            self._path_on_disk(gjob_path, sd=False),
+            self._path_on_disk(out_dir, sd=False),
         )
         return self.queries.importJob(self.ns, manifest, out_dir, draft)
 

--- a/continuousprint/queues/local_test.py
+++ b/continuousprint/queues/local_test.py
@@ -135,6 +135,7 @@ class TestLocalQueueInOrderInitial(unittest.TestCase):
 
 
 # TODO test mv_job
+# TODO test import_job
 
 # TODO test SD card behavior on importing/exporting and printing
 # class TestSD(unittest.TestCase):

--- a/continuousprint/queues/local_test.py
+++ b/continuousprint/queues/local_test.py
@@ -73,6 +73,9 @@ class TestLocalQueueInOrderNoInitialJob(unittest.TestCase):
         self.q.queries.getNextJobInQueue.return_value = None
         self.assertEqual(self.q.acquire(), False)
 
+    def test_import_job(self):
+        pass  # TODO
+
 
 class TestLocalQueueInOrderInitial(unittest.TestCase):
     def setUp(self):
@@ -94,6 +97,9 @@ class TestLocalQueueInOrderInitial(unittest.TestCase):
     def test_init_already_acquired(self):
         self.assertEqual(self.q.get_job(), self.j)
         self.assertEqual(self.q.get_set(), self.s)
+
+    def test_mv(self):
+        pass  # TODO
 
     def test_acquire_2x(self):
         # Second acquire should do nothing, return True
@@ -133,9 +139,6 @@ class TestLocalQueueInOrderInitial(unittest.TestCase):
             ),
         )
 
-
-# TODO test mv_job
-# TODO test import_job
 
 # TODO test SD card behavior on importing/exporting and printing
 # class TestSD(unittest.TestCase):

--- a/continuousprint/script_runner.py
+++ b/continuousprint/script_runner.py
@@ -80,7 +80,7 @@ class ScriptRunner:
                 path = item.resolve()
             except ResolveError as e:
                 self._logger.error(e)
-                self._msg(f"Could not resolve LAN print path {path}", type="error")
+                self._msg(f"Could not resolve LAN print path for {path}", type="error")
                 return False
             self._logger.info(f"Resolved LAN print path to {path}")
 

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -227,6 +227,7 @@
   position: relative;
   flex: 1;
   display: flex; /* allow for stacking progresses in jobs */
+  margin-right: var(--cpq-pad2);
 }
 #tab_plugin_continuousprint .accordion-heading-button {
   padding: var(--cpq-pad) var(--cpq-pad);
@@ -265,6 +266,7 @@
   font-weight: bold;
   opacity: 0.5;
   margin-left: 55px;
+  margin-right: var(--cpq-pad2);
   align-items: flex-end;
 }
 #tab_plugin_continuousprint .queue-header > div, #settings_continuousprint_queues .queue-header > div {

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -216,6 +216,7 @@
 #tab_plugin_continuousprint .set_warning {
   flex: 1;
   text-align: center;
+  margin-right: 17px;
 }
 #tab_plugin_continuousprint .draft .set_warning {
   flex: 0;
@@ -424,3 +425,42 @@
 
 #tab_plugin_continuousprint .header > *, #tab_plugin_continuousprint .entries > .entry > * {
   flex: 1;
+  text-align: center;
+}
+
+#tab_plugin_continuousprint .timelapse_thumbnail {
+	position: relative;
+	display: inline-block;
+}
+
+#tab_plugin_continuousprint .timelapse_thumbnail > img {
+	display: none;
+	cursor: pointer;
+	position: absolute;
+	z-index: 1000;
+	top: 0;
+	max-width: 100px;
+	left: 18px;
+	border: 1px black solid;
+	padding: 5px;
+	background-color: white;
+}
+#tab_plugin_continuousprint .timelapse_thumbnail > i {
+	padding: 2px; /* So hover is maintained when mousing over to image */
+}
+#tab_plugin_continuousprint .timelapse_thumbnail:hover > img {
+  display: block;
+}
+
+#tab_plugin_continuousprint .separator {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+#tab_plugin_continuousprint .separator .line {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid #000;
+  margin-left: 5px;
+  margin-right: 5px;
+}

--- a/continuousprint/static/js/continuousprint_api.js
+++ b/continuousprint/static/js/continuousprint_api.js
@@ -35,13 +35,13 @@ class CPAPI {
           }
         },
         error: (xhr,  textstatus, errThrown) => {
+          if (blocking) {
+            self.loading(false);
+          }
           if (err_cb) {
             err_cb(xhr.status, errThrown);
           } else {
             self.default_err_cb(xhr.status, errThrown);
-          }
-          if (blocking) {
-            self.loading(false);
           }
         }
     });

--- a/continuousprint/static/js/continuousprint_job.js
+++ b/continuousprint/static/js/continuousprint_job.js
@@ -27,15 +27,15 @@ function CPJob(obj, peers, api, profile) {
   self.id = ko.observable(obj.id);
   self._name = ko.observable(obj.name || "");
 
-  if (obj.acquired) {
-    self.acquiredBy = ko.observable('local');
-  } else if (obj.acquired_by_) {
+  if (obj.acquired_by_) {
     let peer = peers[obj.acquired_by_];
     if (peer !== undefined) {
-      self.acquiredBy = ko.observable(peer.name);
+      self.acquiredBy = ko.observable(`${peer.name} (${peer.profile.name})`);
     } else {
       self.acquiredBy = ko.observable(obj.acquired_by_)
     }
+  } else if (obj.acquired) {
+    self.acquiredBy = ko.observable('local');
   } else {
     self.acquiredBy = ko.observable();
   }

--- a/continuousprint/static/js/continuousprint_set.js
+++ b/continuousprint/static/js/continuousprint_set.js
@@ -121,7 +121,7 @@ function CPSet(data, job, api, profile) {
     return result;
   });
   self.pct_complete = ko.computed(function() {
-    let cplt = self.completed()
+    let cplt = self.completed();
     let total = cplt + self.remaining();
     return Math.max(0, Math.round(100 * cplt/total)) + '%';
   });
@@ -129,7 +129,7 @@ function CPSet(data, job, api, profile) {
     return Math.max(0, Math.round(100 / (self.completed() + self.remaining()))) + '%';
   });
   self.progress_text = ko.computed(function() {
-    let cplt = self.completed()
+    let cplt = self.completed();
     let total = cplt + self.remaining();
     return `${cplt}/${total}`;
   });

--- a/continuousprint/static/js/continuousprint_viewmodel.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.js
@@ -43,7 +43,6 @@ function CPViewModel(parameters) {
     self.defaultQueue = null;
     self.expanded = ko.observable(null);
     self.profile = ko.observable('');
-    self.showStats = ko.observable(false);
 
     self.api = parameters[5] || new CPAPI();
 
@@ -230,7 +229,20 @@ function CPViewModel(parameters) {
       self.draggingJob(vm.constructor.name === "CPJob");
     };
 
-    self.sortEnd = function(evt, vm, src, dataFor=ko.dataFor) {
+    self._getElemIdx = function(elem, pcls) {
+      while (!elem.classList.contains(pcls)) {
+        elem = elem.parentElement;
+      }
+      let siblings = elem.parentElement.children;
+      for (let i=0; i < siblings.length; i++) {
+        if (siblings[i] === elem) {
+          return i;
+        }
+      }
+      return null;
+    };
+
+    self.sortEnd = function(evt, vm, src) {
       // Re-enable default drag and drop behavior
       self.files.onServerConnect();
       self.draggingSet(false);
@@ -239,14 +251,8 @@ function CPViewModel(parameters) {
       // Sadly there's no "destination job" information, so we have to
       // infer the index of the job based on the rendered HTML given by evt.to
       if (vm.constructor.name === "CPJob") {
-        let jobs = self.defaultQueue.jobs();
-        let destq = dataFor(evt.to);
-        let dest_idx = destq.jobs().indexOf(vm);
-
-        let ids = []
-        for (let j of jobs) {
-          ids.push(j.id());
-        }
+        let destq = self.queues()[self._getElemIdx(evt.to, "cp-queue")];
+        let dest_idx = evt.newIndex;
         self.api.mv(self.api.JOB, {
             src_queue: src.name,
             dest_queue: destq.name,

--- a/continuousprint/static/js/continuousprint_viewmodel.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.js
@@ -176,11 +176,11 @@ function CPViewModel(parameters) {
         }
         let cpq = new CPQueue(q, self.api, self.files, self.profile);
 
-        // Replace draft entries
+        // Replace draft entries that are still in draft
         let cpqj = cpq.jobs();
         for (let i = 0; i < q.jobs.length; i++) {
           let draft = drafts[cpqj[i].id()];
-          if (draft !== undefined) {
+          if (draft !== undefined && cpqj[i].draft()) {
             cpq.jobs.splice(i, 1, draft);
           }
         }
@@ -262,6 +262,9 @@ function CPViewModel(parameters) {
           if (result.error) {
             self.onDataUpdaterPluginMessage("continuousprint", {type: "error", msg: result.error});
           }
+          // Refresh in case of error or if the move modified job internals (e.g. on job submission)
+          // Do this as a timeout to allow for UI rendering / RPC calls to complete
+          setTimeout(self._loadState, 0);
         });
       }
     };

--- a/continuousprint/static/js/continuousprint_viewmodel.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.js
@@ -242,7 +242,7 @@ function CPViewModel(parameters) {
       return null;
     };
 
-    self.sortEnd = function(evt, vm, src) {
+    self.sortEnd = function(evt, vm, src, idx=null) {
       // Re-enable default drag and drop behavior
       self.files.onServerConnect();
       self.draggingSet(false);

--- a/continuousprint/static/js/continuousprint_viewmodel.test.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.test.js
@@ -161,8 +161,9 @@ test('sortEnd job to start', () => {
 
 test.only('sortEnd job to end', () => {
   let v = init(njobs=2);
+  v._getElemIdx = () => 0; // To get queue
   let ccont = {classList: {contains: () => true}};
-  let evt = {from: ccont, to: ccont};
+  let evt = {from: ccont, to: ccont, newIndex: 1};
   let j = v.defaultQueue.jobs()[1];
   v.sortEnd(evt, j, v.defaultQueue, dataFor=function(elem) {return v.defaultQueue});
   expect(v.files.onServerConnect).toHaveBeenCalled();

--- a/continuousprint/static/js/continuousprint_viewmodel.test.js
+++ b/continuousprint/static/js/continuousprint_viewmodel.test.js
@@ -148,8 +148,9 @@ describe('sortMove', () => {
 
 test('sortEnd job to start', () => {
   let v = init();
+  v._getElemIdx = () => 0; // To get queue
   let ccont = {classList: {contains: () => true}};
-  let evt = {from: ccont, to: ccont};
+  let evt = {from: ccont, to: ccont, newIndex: 0};
   let j = v.defaultQueue.jobs()[0];
   v.sortEnd(evt, j, v.defaultQueue, dataFor=function(elem) {return v.defaultQueue});
   expect(v.files.onServerConnect).toHaveBeenCalled();
@@ -159,7 +160,7 @@ test('sortEnd job to start', () => {
   expect(data.after_id).toEqual(null);
 });
 
-test.only('sortEnd job to end', () => {
+test('sortEnd job to end', () => {
   let v = init(njobs=2);
   v._getElemIdx = () => 0; // To get queue
   let ccont = {classList: {contains: () => true}};

--- a/continuousprint/storage/database.py
+++ b/continuousprint/storage/database.py
@@ -152,7 +152,7 @@ class Job(Model, JobView):
         return j
 
     def refresh_sets(self):
-        Set.update(remaining=Set.count).where(Set.job == self).execute()
+        Set.update(remaining=Set.count, completed=0).where(Set.job == self).execute()
 
 
 class SetView:

--- a/continuousprint/storage/database_test.py
+++ b/continuousprint/storage/database_test.py
@@ -182,10 +182,12 @@ class TestJobWithSet(DBTest):
 
     def testDecrementCompletedSet(self):
         self.s.remaining = 0
+        self.s.completed = 5
         self.s.save()
         self.j.decrement()
         self.assertEqual(self.j.remaining, 4)
         self.assertEqual(self.j.sets[0].remaining, 5)
+        self.assertEqual(self.j.sets[0].completed, 0)
 
     def testDecrementPartialSet(self):
         self.s.remaining = 3

--- a/continuousprint/storage/lan_test.py
+++ b/continuousprint/storage/lan_test.py
@@ -39,3 +39,11 @@ class LANViewTest(unittest.TestCase):
             self.lq.set_job.call_args[0][1]["sets"][0]["remaining"], self.s.count
         )
         self.assertEqual(self.lq.set_job.call_args[0][1]["sets"][0]["completed"], 0)
+
+    def test_save_persists_peer_and_hash(self):
+        self.j.peer = "foo"
+        self.j.hash = "bar"
+        self.j.save()
+        data = self.lq.set_job.call_args[0][1]
+        self.assertEqual(data["peer_"], "foo")
+        self.assertEqual(data["hash"], "bar")

--- a/continuousprint/storage/lan_test.py
+++ b/continuousprint/storage/lan_test.py
@@ -32,8 +32,10 @@ class LANViewTest(unittest.TestCase):
 
     def test_decrement_refreshes_sets_and_saves(self):
         self.s.remaining = 0
+        self.s.completed = 5
         self.j.decrement()
         self.lq.set_job.assert_called()
         self.assertEqual(
             self.lq.set_job.call_args[0][1]["sets"][0]["remaining"], self.s.count
         )
+        self.assertEqual(self.lq.set_job.call_args[0][1]["sets"][0]["completed"], 0)

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -150,7 +150,7 @@
               <!-- ko if: !draft() -->
               <div class="job-name" data-bind="text: _name"></div>
               <!-- /ko -->
-              <div class="progress" title="The number of iterations/runs completed out of the total for the job" data-bind="css: { 'progress-striped active': queue.active_jobs().indexOf(id()) !== -1}">
+              <div class="progress" title="The number of iterations/runs completed out of the total for the job" data-bind="css: { 'active': $root.status() === 'Printing', 'progress-striped': queue.active_jobs().indexOf(id()) !== -1}">
                 <div class="progresstext" data-bind="text: $root.humanize(completed()) + '/' + $root.humanize(count())"></div>
                 <div data-bind="visible: pct_complete() !== '0%', style: { width: pct_complete() }" class="bar bar-success"></div>
                 <div data-bind="visible: queue.active_jobs().indexOf(id()) !== -1, style: { width: pct_active() }" class="bar active"></div>
@@ -187,7 +187,7 @@
                           <i class="fas fa-exclamation-triangle" style="color: #aa0000"></i>
                         </div>
                         <!-- ko if: !job.draft() || queue.active_sets().indexOf(id) !== -1 -->
-                        <div class="progress" title="The number of iterations out of the total for this iteration/run of the job" data-bind="hidden: !profile_matches() || missing_file(), css: { 'progress-striped active': queue.active_sets().indexOf(id) !== -1 }">
+                        <div class="progress" title="The number of iterations out of the total for this iteration/run of the job" data-bind="hidden: !profile_matches() || missing_file(), css: { 'active': $root.status() === 'Printing',  'progress-striped': queue.active_sets().indexOf(id) !== -1 }">
                           <div class="progresstext" data-bind="text: progress_text"></div>
                           <div data-bind="visible: pct_complete() !== '0%', style: { width: pct_complete() }" class="bar bar-success"></div>
                           <div data-bind="visible: queue.active_sets().indexOf(id) !== -1, style: { width: pct_active() }" class="bar active"></div>
@@ -199,6 +199,7 @@
 
                           <input class="count fa fa-text count-box" type="number" min="0" data-bind="textInput: count, attr: {'_vkenabled': false}, event: {keypress: job.onEnter, focus: onCountFocus, blur: onCountBlur}"></input>
                           <input class="remaining fa fa-text count-box" type="number" min="0" data-bind="textInput: remaining, attr: {'_vkenabled': false}, event: {keypress: job.onEnter}"></input>
+                          <div class="total" data-bind="text: $root.humanize(length_remaining())"></div>
                         <!-- /ko -->
                       </div>
                     </div>

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -103,14 +103,6 @@
               <i style="cursor: pointer" class="far fa-save"></i>
             </button>
           </div>
-          <div class="dropdown" style="z-index:1;">
-            <a class="btn dropdown-toggle" data-toggle="dropdown">
-              <i style="cursor: pointer" class="fas fa-ellipsis-v"></i>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
-              <li><a tabindex="-1" data-bind="click: $root.showStats(!$root.showStats())">Toggle Stats</a></li>
-            </ul>
-          </div>
         </div>
         <div style="flex: 1; text-align: right">
           <span data-bind="visible: $root.queues().length > 1, text: name"></span>
@@ -124,8 +116,6 @@
       <div class="queue-header">
         <div style="flex: 1" class="has_title" title="Jobs are collections of Sets (print files) run one or more times">Job<sup>?</sup></div>
         <div style="flex: 1" class="has_title" title="The number of iterations/runs completed out of the total. For Sets (print files), this is progress on the current iteration of the Job.">Progress<sup>?</sup></div>
-        <div class="remaining has_title" data-bind="visible: $root.showStats()" title="Number of prints yet to be printed for the current job iteration">This Run<sup>?</sup></div>
-        <div class="total has_title" data-bind="visible: $root.showStats()" title="Total number of prints yet to be printed across all remaining iterations of the job">Pending<sup>?</sup></div>
       </div>
       <!-- `cpsortable` is renamed from `sortable` - see https://github.com/smartin015/continuousprint/issues/14 -->
       <div class="accordion queue-list">
@@ -165,8 +155,6 @@
                 <div data-bind="visible: pct_complete() !== '0%', style: { width: pct_complete() }" class="bar bar-success"></div>
                 <div data-bind="visible: queue.active_jobs().indexOf(id()) !== -1, style: { width: pct_active() }" class="bar active"></div>
               </div>
-              <div class="remaining" data-bind="visible: $root.showStats(), text: $root.humanize(totals().remaining)"></div>
-              <div class="total" data-bind="visible: $root.showStats(), text: $root.humanize(totals().total)"></div>
             </div>
           </div>
           <div class="accordion-body collapse in">
@@ -204,7 +192,6 @@
                           <div data-bind="visible: pct_complete() !== '0%', style: { width: pct_complete() }" class="bar bar-success"></div>
                           <div data-bind="visible: queue.active_sets().indexOf(id) !== -1, style: { width: pct_active() }" class="bar active"></div>
                         </div>
-                        <div class="remaining" data-bind="text: $root.humanize(remaining()), visible: $root.showStats()"></div>
                         <!-- /ko -->
                         <!-- ko if: job.draft() && queue.active_sets().indexOf(id) === -1 -->
                           <div class="completed" data-bind="text: $root.humanize(completed())"></div>
@@ -213,7 +200,6 @@
                           <input class="count fa fa-text count-box" type="number" min="0" data-bind="textInput: count, attr: {'_vkenabled': false}, event: {keypress: job.onEnter, focus: onCountFocus, blur: onCountBlur}"></input>
                           <input class="remaining fa fa-text count-box" type="number" min="0" data-bind="textInput: remaining, attr: {'_vkenabled': false}, event: {keypress: job.onEnter}"></input>
                         <!-- /ko -->
-                          <div class="total" data-bind="text: $root.humanize(length_remaining()), visible: job.draft() || $root.showStats()"></div>
                       </div>
                     </div>
                   <div class="accordion-body collapse" data-bind="css: {'in': set.expanded}">

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "continuousprint"
 plugin_name = "continuousprint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "2.1.1"
+plugin_version = "2.1.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
QA checks to verify correct behavior in light of #101:

* [x] Can create empty job
* [x] Can add items to job
* [x] Can create second empty job and move items to the other job
* [x] Can export gjob files from local queue
* [x] Can import gjob files from local queue
* [x] Can print a job with 2 repeats, containing 2 sets with 2 repeats
* [x] Deleting gcode file displays error in queue
* [x] Print files skipped if wrong print profile
* [x] Await printing if wrong color
* [x] Can drag+drop onto LAN queue and print a thing remotely (confirm with two instances of octoprint, diff profiles)
* [x] Can edit and save a LAN job mid-print, with the correct number of items printed after edit
* [x] Can delete a job from the lan queue
* [x] Can reset a job in the local queue
* [x] Can delete jobs in the local queue
* [x] Job multiselect works
* [x] Job multiselect-by-incomplete/completed/unstarted works
* [x] Drag-drop job with autostart behavior works
* [x] Can create additional LAN queue
* [x] Can move print between LAN queues
* [x] Can delete a LAN queue
* [x] Timelapses saved in job history
* [x] Job position reverted back to prev queue if LAN queue validation fails
* [x] Completion count of sets is consistent between local and lan queues (i.e. turns back to 0 when job run completes)
* [x] Editing and saving a lan job syncs edit state across peers
* [x] Joining an existing lan queue also syncs files