### PR TITLE
Fix DB 0.0.3 migration script

### DIFF
--- a/continuousprint/storage/database.py
+++ b/continuousprint/storage/database.py
@@ -330,11 +330,20 @@ def init(db_path="queues.sqlite3", logger=None):
 
                 if logger is not None:
                     logger.warning(
-                        f"Beginning migration to v0.0.3 - {Set.select().count()} sets to migrate"
+                        f"Beginning migration to v0.0.3 for decoupled completions - {Set.select().count()} sets to migrate"
                     )
                 with db.atomic():
                     TempSet.create_table(safe=True)
-                    for s in Set.select().execute():
+                    for s in Set.select(
+                        Set.path,
+                        Set.sd,
+                        Set.job,
+                        Set.rank,
+                        Set.count,
+                        Set.remaining,
+                        Set.material_keys,
+                        Set.profile_keys,
+                    ).execute():
                         attrs = {}
                         for f in Set._meta.sorted_field_names:
                             attrs[f] = getattr(s, f)


### PR DESCRIPTION
Need to select specific fields of sets when migrating to schema v0.0.3, as otherwise the not-yet-created `completed` field attempts to be selected and causes a query error.