### PR TITLE
Improve IP address resolution

### DIFF
--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -130,12 +130,8 @@ class CPQPlugin(ContinuousPrintAPI):
         return port
 
     def get_local_ip(self):
-        # https://stackoverflow.com/a/57355707
-        hostname = socket.gethostname()
-        try:
-            return socket.gethostbyname(f"{hostname}.local")
-        except socket.gaierror:
-            return socket.gethostbyname(hostname)
+        ip_address = [(s.connect((self._settings.global_get(["server","onlineCheck","host"]), self._settings.global_get(["server","onlineCheck","port"]))), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]
+        return ip_address
 
     def _add_set(self, path, sd, draft=True, profiles=[]):
         # We may need to delay adding a file if it hasn't yet finished analysis


### PR DESCRIPTION
I run all my Octoprint instances on a Docker Compose setup using a fork of the Octoprint official Docker image.   I was having errors starting Continuous Print because it couldn't resolve the local IP address using the mDNS lookup approach.   

 `2022-10-18 22:22:06  socket.gaierror: [Errno -5] No address associated with hostname`
 `2022-10-18 22:22:06    return socket.gethostbyname(hostname)`
 `2022-10-18 22:22:06    File "/octoprint/plugins/lib/python3.8/site-packages/continuousprint/plugin.py", line 135, in get_local_ip`
 `2022-10-18 22:22:06    local_ip=self._plugin.get_local_ip(),`

I posted this problem in #support-plugins on the OctoPrint discord and jneiliii suggested the change in this PR.   It's used in another of his plugins here: https://github.com/jneilliii/OctoPrint-ipOnConnect/blob/4743a1ff71cc090f00f353bffe32213d2a13e8a2/octoprint_ipOnConnect/__init__.py#L39

This works for me, thought I'd pass it along and see if this makes sense up stream.   I was expecting LAN queues to not work if I was having mDNS resolution troubles, but it's working great as well.   
