### PR TITLE
Network hardening

### DIFF
--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -96,11 +96,16 @@ class ContinuousprintPlugin(
 
     # ---------------------- Begin TemplatePlugin -------------------
     def get_template_vars(self):
+        try:
+            local_ip = self._plugin.get_local_addr().split(":")[0]
+        except Exception:
+            # Local IP details are used for display only
+            local_ip = "<ip_address>"
         return dict(
             printer_profiles=list(PRINTER_PROFILES.values()),
             gcode_scripts=list(GCODE_SCRIPTS.values()),
             custom_events=[e.as_dict() for e in CustomEvents],
-            local_ip=self._plugin.get_local_ip(),
+            local_ip=local_ip,
         )
 
     def get_template_configs(self):

--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -102,6 +102,7 @@ class ContinuousprintPlugin(
             # Local IP details are used for display only
             local_ip = "<ip_address>"
         return dict(
+            exceptions=self._plugin.get_exceptions(),
             printer_profiles=list(PRINTER_PROFILES.values()),
             gcode_scripts=list(GCODE_SCRIPTS.values()),
             custom_events=[e.as_dict() for e in CustomEvents],

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -79,6 +79,7 @@ class CPQPlugin(ContinuousPrintAPI):
         self._reconnect_attempts = 0
         self._next_reconnect = 0
         self._fire_event = fire_event
+        self._exceptions = []
 
     def start(self):
         self._setup_thirdparty_plugin_integration()
@@ -243,8 +244,12 @@ class CPQPlugin(ContinuousPrintAPI):
         # See continuousprint_viewmodel.js onDataUpdaterPluginMessage
         self._plugin_manager.send_plugin_message(self._identifier, data)
 
+    def get_exceptions(self):
+        return self._exceptions
+
     def _exception_msg(self, msg):
         self._logger.error(msg)
+        self._exceptions.append(msg)
         self._logger.error(traceback.format_exc())
         self._msg(dict(msg=msg + "\n\nSee sysinfo logs for details", type="danger"))
 

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -50,6 +50,7 @@ class CPQPlugin(ContinuousPrintAPI):
     )
     RECONNECT_WINDOW_SIZE = 5.0
     MAX_WINDOW_EXP = 6
+    GET_ADDR_TIMEOUT = 3
     CPQ_ANALYSIS_FINISHED = "CPQ_ANALYSIS_FINISHED"
 
     def __init__(
@@ -118,33 +119,61 @@ class CPQPlugin(ContinuousPrintAPI):
         self._update(DA.ACTIVATE)
         self._sync_state()
 
-    def get_open_port(self):
+    def _can_bind_addr(self, addr):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.bind(addr)
+        except OSError:
+            return False
+        finally:
+            s.close()
+        return True
+
+    def get_local_addr(self):
         # https://stackoverflow.com/a/2838309
         # Note that this is vulnerable to race conditions in that
         # the port is open when it's assigned, but could be reassigned
         # before the caller can use it.
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("", 0))
-        s.listen(1)
-        port = s.getsockname()[1]
-        s.close()
-        return port
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(CPQPlugin.GET_ADDR_TIMEOUT)
+        checkaddr = tuple(
+            [
+                self._settings.global_get(["server", "onlineCheck", v])
+                for v in ("host", "port")
+            ]
+        )
+        try:
+            s.connect(checkaddr)
+            result = s.getsockname()
+        finally:
+            # Note: close has no effect on already closed socket
+            s.close()
 
-    def get_local_ip(self):
-        ip_address = [
-            (
-                s.connect(
-                    (
-                        self._settings.global_get(["server", "onlineCheck", "host"]),
-                        self._settings.global_get(["server", "onlineCheck", "port"]),
-                    )
-                ),
-                s.getsockname()[0],
-                s.close(),
-            )
-            for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]
-        ][0][1]
-        return ip_address
+        if self._can_bind_addr(result):
+            return f"{result[0]}:{result[1]}"
+
+        # For whatever reason, client-based local IP resolution can sometimes still fail to bind.
+        # In this case, fall back to MDNS based resolution
+        # https://stackoverflow.com/a/57355707
+        self._logger.warning(
+            "Online check based IP resolution failed to bind; attempting MDNS local IP resolution"
+        )
+        hostname = socket.gethostname()
+        try:
+            local_ip = socket.gethostbyname(f"{hostname}.local")
+        except socket.gaierror:
+            local_ip = socket.gethostbyname(hostname)
+
+        # Find open port: https://stackoverflow.com/a/2838309
+        # This will raise OSError if it cannot bind to that address either
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.bind((local_ip, 0))
+            s.listen(1)
+            port = s.getsockname()[1]
+        finally:
+            s.close()
+        return f"{local_ip}:{port}"
 
     def _add_set(self, path, sd, draft=True, profiles=[]):
         # We may need to delay adding a file if it hasn't yet finished analysis
@@ -214,6 +243,11 @@ class CPQPlugin(ContinuousPrintAPI):
         # See continuousprint_viewmodel.js onDataUpdaterPluginMessage
         self._plugin_manager.send_plugin_message(self._identifier, data)
 
+    def _exception_msg(self, msg):
+        self._logger.error(msg)
+        self._logger.error(traceback.format_exc())
+        self._msg(dict(msg=msg + "\n\nSee sysinfo logs for details", type="danger"))
+
     def _setup_thirdparty_plugin_integration(self):
         # Turn on "restart on pause" when Obico plugin is detected (must be version 1.8.11 or higher for custom event hook)
         if getattr(octoprint.events.Events, "PLUGIN_OBICO_COMMAND", None) is not None:
@@ -255,10 +289,26 @@ class CPQPlugin(ContinuousPrintAPI):
         self.fileshare_dir = self._path_on_disk(
             f"{PRINT_FILE_DIR}/fileshare/", sd=False
         )
-        fileshare_addr = f"{self.get_local_ip()}:0"
+        try:
+            fileshare_addr = self.get_local_addr()
+        except OSError:
+            self._exception_msg(
+                "Failed to find a local addr for LAN fileshare; LAN queues will be disabled."
+            )
+            self._fileshare = None
+            return
+
         self._logger.info(f"Starting fileshare with address {fileshare_addr}")
         self._fileshare = fs_cls(fileshare_addr, self.fileshare_dir, self._logger)
-        self._fileshare.connect()
+        try:
+            self._fileshare.connect()
+            self._logger.info(
+                f"Fileshare listening on {self._fileshare.host}:{self._fileshare.port}"
+            )
+        except OSError:
+            self._exception_msg(
+                "Failed to bind Fileshare HTTP server; hosting LAN jobs will fail, but fetching jobs may still work."
+            )
 
     def _init_db(self):
         init_db(
@@ -310,9 +360,7 @@ class CPQPlugin(ContinuousPrintAPI):
                 try:
                     lq = lancls(
                         q.name,
-                        q.addr
-                        if q.addr.lower() != "auto"
-                        else f"{self.get_local_ip()}:{self.get_open_port()}",
+                        q.addr if q.addr.lower() != "auto" else self.get_local_addr(),
                         self._logger,
                         Strategy.IN_ORDER,
                         self._on_queue_update,
@@ -322,10 +370,11 @@ class CPQPlugin(ContinuousPrintAPI):
                     )
                     lq.connect()
                     self.q.add(q.name, lq)
-                except ValueError:
-                    self._logger.error(
-                        f"Unable to join network queue (name {q.name}, addr {q.addr}) due to ValueError"
+                except Exception:
+                    self._exception_msg(
+                        f'Unable to join network queue "{q.name}" with address {q.addr}'
                     )
+
             elif q.name != ARCHIVE_QUEUE:
                 self.q.add(
                     q.name,
@@ -714,9 +763,7 @@ class CPQPlugin(ContinuousPrintAPI):
             try:
                 lq = LANQueue(
                     a["name"],
-                    a["addr"]
-                    if a["addr"].lower() != "auto"
-                    else f"{self.get_local_ip()}:{self.get_open_port()}",
+                    a["addr"] if a["addr"].lower() != "auto" else self.get_local_addr(),
                     self._logger,
                     Strategy.IN_ORDER,
                     self._on_queue_update,

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -27,8 +27,14 @@ class MockSettings:
     def get(self, k):
         return self.s.get(k[0])
 
+    def global_get(self, gk):
+        return self.get([":".join(gk)])
+
     def set(self, k, v):
         self.s[k[0]] = v
+
+    def global_set(self, gk, v):
+        return self.set([":".join(gk)], v)
 
 
 def mockplugin():
@@ -113,12 +119,27 @@ class TestStartup(unittest.TestCase):
     def testFileshare(self):
         p = mockplugin()
         fs = MagicMock()
-        p.get_local_ip = MagicMock(return_value="111.111.111.111")
+        p.get_local_addr = lambda: ("111.111.111.111:0")
         p._file_manager.path_on_disk.return_value = "/testpath"
 
         p._init_fileshare(fs_cls=fs)
 
         fs.assert_called_with("111.111.111.111:0", "/testpath", logging.getLogger())
+
+    def testFileshareAddrFailure(self):
+        p = mockplugin()
+        fs = MagicMock()
+        p.get_local_addr = MagicMock(side_effect=[OSError("testing")])
+        p._init_fileshare(fs_cls=fs)  # Does not raise exception
+        self.assertEqual(p._fileshare, None)
+
+    def testFileshareConnectFailure(self):
+        p = mockplugin()
+        fs = MagicMock()
+        p.get_local_addr = lambda: "111.111.111.111:0"
+        fs.connect.side_effect = OSError("testing")
+        p._init_fileshare(fs_cls=fs)  # Does not raise exception
+        self.assertEqual(p._fileshare, fs())
 
     def testQueues(self):
         p = mockplugin()
@@ -551,3 +572,25 @@ class TestCleanupFileshare(unittest.TestCase):
             self.assertTrue((p / f"{n}.gcode").exists())
         self.assertFalse((p / "c.gcode").exists())
         self.assertFalse((p / "d").exists())
+
+
+class TestLocalAddressResolution(unittest.TestCase):
+    def setUp(self):
+        self.p = mockplugin()
+
+    @patch("continuousprint.plugin.socket")
+    def testResolutionViaCheckAddrOK(self, msock):
+        self.p._settings.global_set(["server", "onlineCheck", "host"], "checkhost")
+        self.p._settings.global_set(["server", "onlineCheck", "port"], 5678)
+        s = msock.socket()
+        s.getsockname.return_value = ("1.2.3.4", "1234")
+        self.assertEqual(self.p.get_local_addr(), "1.2.3.4:1234")
+        s.connect.assert_called_with(("checkhost", 5678))
+
+    @patch("continuousprint.plugin.socket")
+    def testResolutionFailoverToMDNS(self, msock):
+        self.p._can_bind_addr = lambda a: False
+        msock.gethostbyname.return_value = "1.2.3.4"
+        s = msock.socket()
+        s.getsockname.return_value = ("ignored", "1234")
+        self.assertEqual(self.p.get_local_addr(), "1.2.3.4:1234")

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -8,6 +8,7 @@
   const CP_GCODE_SCRIPTS = {{plugin_continuousprint_gcode_scripts|tojson|safe}};
   const CP_CUSTOM_EVENTS = {{plugin_continuousprint_custom_events|tojson|safe}};
   const CP_LOCAL_IP = {{plugin_continuousprint_local_ip|tojson|safe}};
+  const CP_EXCEPTIONS = {{plugin_continuousprint_exceptions|tojson|safe}};
 </script>
 
 <ul class="nav nav-pills">

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -64,7 +64,22 @@
       <!-- /ko -->
       </div>
   </div>
+
+  <div class="alert alert-error" data-bind="visible: CP_EXCEPTIONS.length > 0">
+    <button type="button" class="close" data-dismiss="alert">&times;</button>
+    <p>
+      <i class="fas fa-exclamation-triangle"></i> Encountered the following exceptions:
+    </p>
+    <ul data-bind="foreach: CP_EXCEPTIONS">
+      <li data-bind="text: $data"></li>
+    </ul>
+    <p>
+      Please <a target="_blank" href="https://github.com/smartin015/continuousprint/issues/new/choose">file a bug report</a> - be sure to follow the template instructions to generate a sysinfo bundle.
+    </p>
+  </div>
+
   <div class="alert alert-warning" data-bind="visible: badMaterialCount">
+    <button type="button" class="close" data-dismiss="alert">&times;</button>
     <i class="fas fa-exclamation-triangle"></i> <span data-bind="text: badMaterialCount"></span> spool(s) configured without a material.
     <br/>These will be excluded from material selection until you configure them (in the Spools tab) and reload.
   </div>
@@ -74,6 +89,7 @@
   </div>
 
   <div id="continuousprint_tab_queues" class="tab-pane active" data-bind="foreach: {data: queues, as: 'queue'}">
+
     <div class="cp-queue" data-bind="css: {'loading': $root.loading() || !ready()}">
     <div class="cp-header action-bar">
         <div class="multiselect">


### PR DESCRIPTION
Addressing #154 and #151, this makes the plugin more resilient to network connection issues on startup. If the LAN fileshare or queues fail to bind to addresses, they are omitted and the plugin continues to start up without them (with a user visible error).