### PR TITLE
Fix edit behavior on lan jobs - properly host the edited job

### DIFF
--- a/continuousprint/queues/lan_test.py
+++ b/continuousprint/queues/lan_test.py
@@ -20,12 +20,17 @@ class LANQueueTest(unittest.TestCase, PeerPrintLANTest):
     def setUp(self):
         PeerPrintLANTest.setUp(self)  # Generate peerprint LANQueue as self.q
         self.q.q.syncPeer(
-            dict(profile=dict(name="profile")), addr=self.q.q.addr
+            dict(
+                profile=dict(name="profile"),
+                fs_addr="mock_fs_addr",
+            ),
+            addr=self.q.q.addr,
         )  # Helps pass validation
         ppq = self.q  # Rename to make way for CPQ LANQueue
 
         self.ucb = MagicMock()
         self.fs = MagicMock()
+        self.fs.fetch.return_value = "asdf.gcode"
         self.q = LANQueue(
             "ns",
             "localhost:1234",

--- a/continuousprint/storage/lan.py
+++ b/continuousprint/storage/lan.py
@@ -30,6 +30,11 @@ class LANJobView(JobView):
     def get_base_dir(self):
         return self.queue.lq.get_gjob_dirpath(self.peer, self.hash)
 
+    def remap_set_paths(self):
+        # Replace all relative/local set paths with fully resolved paths
+        for s in self.sets:
+            s.path = s.resolve()
+
     def updateSets(self, sets_list):
         self.sets = [LANSetView(s, self, i) for i, s in enumerate(sets_list)]
 

--- a/continuousprint/storage/lan_test.py
+++ b/continuousprint/storage/lan_test.py
@@ -25,6 +25,11 @@ class LANViewTest(unittest.TestCase):
         self.lq.get_gjob_dirpath.return_value = "/path/to/"
         self.assertEqual(self.s.resolve(), "/path/to/a.gcode")
 
+    def test_remap_set_paths(self):
+        self.lq.get_gjob_dirpath.return_value = "/path/to/"
+        self.j.remap_set_paths()
+        self.assertEqual(self.s.path, "/path/to/a.gcode")
+
     def test_resolve_http_error(self):
         self.lq.get_gjob_dirpath.side_effect = HTTPError
         with self.assertRaises(ResolveError):


### PR DESCRIPTION
Addressing #151, where a 500 error would happen when attempting to edit a job not hosted by that peer.