### PR TITLE
Better script interaction

### DIFF
--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -64,6 +64,7 @@ class ContinuousprintPlugin(
             )
 
     def on_after_startup(self):
+        self._plugin.patchComms()
         self._plugin.start()
 
         # It's possible to miss events or for some weirdness to occur in conditionals. Adding a watchdog

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -16,7 +16,7 @@ import octoprint.timelapse
 
 from peerprint.filesharing import Fileshare
 from .analysis import CPQProfileAnalysisQueue
-from .driver import Driver, Action as DA, Printer as DP
+from .driver import Driver, Action as DA, Printer as DP, shouldBlockCoreEvents
 from .queues.lan import LANQueue
 from .queues.multi import MultiQueue
 from .queues.local import LocalQueue
@@ -811,3 +811,26 @@ class CPQPlugin(ContinuousPrintAPI):
         # We trigger state update rather than returning it here, because this is called by the settings viewmodel
         # (not the main viewmodel that displays the queues)
         self._sync_state()
+
+    def patchComms(self):
+        # Patch the comms interface to allow for suppressing GCODE script events when the
+        # qeue is running script events
+        self._sendGcodeScriptOrig = self._printer._comm.sendGcodeScript
+        self._printer._comm.sendGcodeScript = self.gatedSendGcodeScript
+        self._logger.info("Patched sendGCodeScript")
+
+    def gatedSendGcodeScript(self, *args, **kwargs):
+        # As this patches core OctoPrint functionality, we wrap *everything*
+        # in try/catch to ensure it continues to execute if CPQ raises an exception.
+        shouldCall = True
+        try:
+            if shouldBlockCoreEvents(self.d.state):
+                shouldCall = False
+                self._logger.warning(
+                    f"Suppressing sendGcodeScript({args[0]}) as driver is in state {self.d.state}"
+                )
+        except Exception:
+            self._logger.error(traceback.format_exc())
+        finally:
+            if shouldCall:
+                self._sendGcodeScriptOrig(*args, **kwargs)

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -836,4 +836,4 @@ class CPQPlugin(ContinuousPrintAPI):
             self._logger.error(traceback.format_exc())
         finally:
             if shouldCall:
-                self._sendGcodeScriptOrig(*args, **kwargs)
+                return self._sendGcodeScriptOrig(*args, **kwargs)

--- a/continuousprint/plugin.py
+++ b/continuousprint/plugin.py
@@ -815,9 +815,12 @@ class CPQPlugin(ContinuousPrintAPI):
     def patchComms(self):
         # Patch the comms interface to allow for suppressing GCODE script events when the
         # qeue is running script events
-        self._sendGcodeScriptOrig = self._printer._comm.sendGcodeScript
-        self._printer._comm.sendGcodeScript = self.gatedSendGcodeScript
-        self._logger.info("Patched sendGCodeScript")
+        try:
+            self._sendGcodeScriptOrig = self._printer._comm.sendGcodeScript
+            self._printer._comm.sendGcodeScript = self.gatedSendGcodeScript
+            self._logger.info("Patched sendGCodeScript")
+        except Exception:
+            self._logger.error(traceback.format_exc())
 
     def gatedSendGcodeScript(self, *args, **kwargs):
         # As this patches core OctoPrint functionality, we wrap *everything*

--- a/continuousprint/plugin_test.py
+++ b/continuousprint/plugin_test.py
@@ -4,9 +4,9 @@ from collections import namedtuple
 from .analysis import CPQProfileAnalysisQueue
 from .storage.queries import getJobsAndSets
 from .storage.database import DEFAULT_QUEUE, ARCHIVE_QUEUE
-from unittest.mock import MagicMock, patch, ANY, call
+from unittest.mock import MagicMock, patch, ANY, call, PropertyMock
 from octoprint.filemanager.analysis import QueueEntry
-from .driver import Action as DA
+from .driver import Driver, Action as DA
 from octoprint.events import Events
 import logging
 import tempfile
@@ -37,7 +37,7 @@ class MockSettings:
         return self.set([":".join(gk)], v)
 
 
-def mockplugin():
+def setupPlugin():
     return CPQPlugin(
         printer=MagicMock(),
         settings=MockSettings(),
@@ -54,7 +54,7 @@ def mockplugin():
 
 class TestStartup(unittest.TestCase):
     def testThirdPartyMissing(self):
-        p = mockplugin()
+        p = setupPlugin()
         p._plugin_manager.plugins.get.return_value = None
 
         p._setup_thirdparty_plugin_integration()
@@ -63,7 +63,7 @@ class TestStartup(unittest.TestCase):
         self.assertEqual(p._get_key(Keys.RESTART_ON_PAUSE), False)  # Obico
 
     def testObicoFound(self):
-        p = mockplugin()
+        p = setupPlugin()
         p._plugin_manager.plugins.get.return_value = None
 
         with patch(
@@ -75,7 +75,7 @@ class TestStartup(unittest.TestCase):
         self.assertEqual(p._get_key(Keys.RESTART_ON_PAUSE), True)  # Obico
 
     def testSpoolManagerFound(self):
-        p = mockplugin()
+        p = setupPlugin()
         p._plugin_manager.plugins.get.return_value = MagicMock()
 
         p._setup_thirdparty_plugin_integration()
@@ -84,15 +84,39 @@ class TestStartup(unittest.TestCase):
         self.assertEqual(p._get_key(Keys.MATERIAL_SELECTION), True)  # Spoolmanager
         self.assertEqual(p._get_key(Keys.RESTART_ON_PAUSE), False)  # Obico
 
+    def testPatchComms(self):
+        p = setupPlugin()
+        sgs = p._printer._comm.sendGcodeScript
+        p.patchComms()
+
+        # Suppress states in which we're running user configured event scripts
+        sgs.reset_mock()
+        p.d = MagicMock(state=Driver._state_activating)
+        p._printer._comm.sendGcodeScript("FOO")
+        sgs.assert_not_called()
+
+        # Pass through states where default OctoPrint behavior should be obeyed
+        sgs.reset_mock()
+        p.d = MagicMock(state=Driver._state_printing)
+        p._printer._comm.sendGcodeScript("FOO")
+        sgs.assert_called()
+
+        # Passthru still happens despite exceptions
+        sgs.reset_mock()
+        p.d = MagicMock()
+        type(p.d).state = PropertyMock(side_effect=Exception("testing error"))
+        p._printer._comm.sendGcodeScript("FOO")
+        sgs.assert_called()
+
     def testDBNew(self):
-        p = mockplugin()
+        p = setupPlugin()
         with tempfile.TemporaryDirectory() as td:
             p._data_folder = td
             p._init_db()
 
     @patch("continuousprint.plugin.migrateScriptsFromSettings")
     def testDBMigrateScripts(self, msfs):
-        p = mockplugin()
+        p = setupPlugin()
         p._set_key(Keys.CLEARING_SCRIPT_DEPRECATED, "s1")
         p._set_key(Keys.FINISHED_SCRIPT_DEPRECATED, "s2")
         p._set_key(Keys.BED_COOLDOWN_SCRIPT_DEPRECATED, "s3")
@@ -103,7 +127,7 @@ class TestStartup(unittest.TestCase):
             msfs.assert_called_with("s1", "s2", "s3")
 
     def testDBWithLegacySettings(self):
-        p = mockplugin()
+        p = setupPlugin()
         p._set_key(
             Keys.QUEUE_DEPRECATED,
             json.dumps(
@@ -129,7 +153,7 @@ class TestStartup(unittest.TestCase):
             self.assertEqual(len(getJobsAndSets(DEFAULT_QUEUE)), 1)
 
     def testFileshare(self):
-        p = mockplugin()
+        p = setupPlugin()
         fs = MagicMock()
         p.get_local_addr = lambda: ("111.111.111.111:0")
         p._file_manager.path_on_disk.return_value = "/testpath"
@@ -139,14 +163,14 @@ class TestStartup(unittest.TestCase):
         fs.assert_called_with("111.111.111.111:0", "/testpath", logging.getLogger())
 
     def testFileshareAddrFailure(self):
-        p = mockplugin()
+        p = setupPlugin()
         fs = MagicMock()
         p.get_local_addr = MagicMock(side_effect=[OSError("testing")])
         p._init_fileshare(fs_cls=fs)  # Does not raise exception
         self.assertEqual(p._fileshare, None)
 
     def testFileshareConnectFailure(self):
-        p = mockplugin()
+        p = setupPlugin()
         fs = MagicMock()
         p.get_local_addr = lambda: "111.111.111.111:0"
         fs.connect.side_effect = OSError("testing")
@@ -154,7 +178,7 @@ class TestStartup(unittest.TestCase):
         self.assertEqual(p._fileshare, fs())
 
     def testQueues(self):
-        p = mockplugin()
+        p = setupPlugin()
         QT = namedtuple("MockQueue", ["name", "addr"])
         p._queries.getQueues.return_value = [
             QT(name="LAN", addr="0.0.0.0:0"),
@@ -166,7 +190,7 @@ class TestStartup(unittest.TestCase):
         self.assertEqual(len(p.q.queues), 2)  # 2 queues created, archive skipped
 
     def testDriver(self):
-        p = mockplugin()
+        p = setupPlugin()
         p.q = MagicMock()
         p._sync_state = MagicMock()
         p._printer_profile = None
@@ -178,7 +202,7 @@ class TestStartup(unittest.TestCase):
 
 class TestEventHandling(unittest.TestCase):
     def setUp(self):
-        self.p = mockplugin()
+        self.p = setupPlugin()
         self.p._spool_manager = None
         self.p._printer_profile = None
         self.p.d = MagicMock()
@@ -364,7 +388,7 @@ class TestEventHandling(unittest.TestCase):
 
 class TestGetters(unittest.TestCase):
     def setUp(self):
-        self.p = mockplugin()
+        self.p = setupPlugin()
         self.p._spool_manager = None
         self.p._printer_profile = None
         self.p.d = MagicMock()
@@ -415,7 +439,7 @@ class TestGetters(unittest.TestCase):
 
 class TestAutoReconnect(unittest.TestCase):
     def setUp(self):
-        self.p = mockplugin()
+        self.p = setupPlugin()
 
     def testOfflineAutoReconnectDisabledByDefault(self):
         # No need to _set_key here, since it should be off by default (prevent unexpected
@@ -467,7 +491,7 @@ class TestAutoReconnect(unittest.TestCase):
 
 class TestAnalysis(unittest.TestCase):
     def setUp(self):
-        self.p = mockplugin()
+        self.p = setupPlugin()
 
     def testInitAnalysisNoFiles(self):
         self.p._file_manager.list_files.return_value = dict(local=dict())
@@ -562,7 +586,7 @@ class TestCleanupFileshare(unittest.TestCase):
                 {"hash": "d", "peer_": "peer2", "acquired_by_": None},
             ]
         )
-        self.p = mockplugin()
+        self.p = setupPlugin()
         self.p.fileshare_dir = self.td.name
         self.p.q = MagicMock()
         self.p.q.queues.items.return_value = [("q", q)]
@@ -588,7 +612,7 @@ class TestCleanupFileshare(unittest.TestCase):
 
 class TestLocalAddressResolution(unittest.TestCase):
     def setUp(self):
-        self.p = mockplugin()
+        self.p = setupPlugin()
 
     @patch("continuousprint.plugin.socket")
     def testResolutionViaCheckAddrOK(self, msock):


### PR DESCRIPTION
Fixes #175 by suppressing core OctoPrint GCODE scripts from running in CPQ states where we're likely running scripts of our own.