### PR TITLE
Preprocessor simulator and preview

### DIFF
--- a/continuousprint/__init__.py
+++ b/continuousprint/__init__.py
@@ -12,6 +12,7 @@ from .data import (
     ASSETS,
     TEMPLATES,
     update_info,
+    SIMULATOR_DEFAULT_SYMTABLE,
 )
 from .storage import queries
 from .api import Permission as CPQPermission
@@ -110,6 +111,7 @@ class ContinuousprintPlugin(
             gcode_scripts=list(GCODE_SCRIPTS.values()),
             custom_events=[e.as_dict() for e in CustomEvents],
             local_ip=local_ip,
+            simulator_default_symtable=SIMULATOR_DEFAULT_SYMTABLE,
         )
 
     def get_template_configs(self):

--- a/continuousprint/api.py
+++ b/continuousprint/api.py
@@ -3,6 +3,7 @@ from enum import Enum
 from octoprint.access.permissions import Permissions, ADMIN_GROUP
 from octoprint.server.util.flask import restricted_access
 from .queues.lan import ValidationError
+from .automation import getInterpreter, genEventScript
 import flask
 import json
 from .storage import queries
@@ -353,10 +354,10 @@ class ContinuousPrintAPI(ABC, octoprint.plugin.BlueprintPlugin):
     def simulate_automation(self):
         symtable = json.loads(flask.request.form.get("symtable"))
         automation = json.loads(flask.request.form.get("automation"))
-        interp, out, err = queries.getInterpreter(symtable)
+        interp, out, err = getInterpreter(symtable)
         symtable = interp.symtable.copy()  # Pick up defaults
         result = dict(
-            gcode=queries.genEventScript(automation, interp),
+            gcode=genEventScript(automation, interp),
             symtable_diff={},
         )
 

--- a/continuousprint/automation.py
+++ b/continuousprint/automation.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import re
 from asteval import Interpreter
 
 

--- a/continuousprint/automation.py
+++ b/continuousprint/automation.py
@@ -1,0 +1,44 @@
+from io import StringIO
+from asteval import Interpreter
+
+
+def getInterpreter(symbols):
+    out = StringIO()
+    err = StringIO()
+    interp = Interpreter(writer=out, err_writer=err)
+    # Merge in so default symbols (e.g. exceptions) are retained
+    for (k, v) in symbols.items():
+        interp.symtable[k] = v
+    return interp, out, err
+
+
+def genEventScript(automation: list, interp=None, logger=None) -> str:
+    result = []
+    for script, preprocessor in automation:
+        procval = True
+        if preprocessor is not None and preprocessor.strip() != "":
+            procval = interp(preprocessor)
+            if logger:
+                logger.info(
+                    f"EventHook preprocessor: {preprocessor}\nSymbols: {interp.symtable}\nResult: {procval}"
+                )
+
+        if procval is None or procval is False:
+            continue
+        elif procval is True:
+            formatted = script
+        elif type(procval) is dict:
+            if logger:
+                logger.info(f"Appending script using formatting data {procval}")
+            formatted = script.format(**procval)
+        else:
+            raise Exception(
+                f"Invalid return type {type(procval)} for peprocessor {preprocessor}"
+            )
+
+        leftovers = re.findall(r"\{.*?\}", formatted)
+        if len(leftovers) > 0:
+            ppname = " (preprocessed)" if e.preprocessor is not None else ""
+            raise Exception(f"Unformatted placeholders in script{ppname}: {leftovers}")
+        result.append(formatted)
+    return "\n".join(result)

--- a/continuousprint/automation_test.py
+++ b/continuousprint/automation_test.py
@@ -1,0 +1,37 @@
+import unittest
+from .automation import getInterpreter, genEventScript
+
+
+class TestInterpreter(unittest.TestCase):
+    def testGetInterpreter(self):
+        interp, _, _ = getInterpreter(dict(a=1))
+        self.assertEqual(interp.symtable["a"], 1)
+
+
+class TestGenEventScript(AutomationDBTest):
+    def testEvalTrueFalseNone(self):
+        a = [("gcode1", "p1")]
+        self.assertEqual(genEventScript(a, lambda cond: True), "gcode1")
+        self.assertEqual(genEventScript(a, lambda cond: False), "")
+        self.assertEqual(genEventScript(a, lambda cond: None), "")
+
+    def testPlaceholderNoPreprocessor(self):
+        a = [("{foo} will never be formatted!", None)]
+        with self.assertRaises(Exception):
+            q.genEventScript(a, lambda cond: False)
+
+    def testEvalMissedPlaceholder(self):
+        a = [("{foo} will never be formatted!", "p1")]
+        with self.assertRaises(Exception):
+            q.genEventScript(a, lambda cond: dict(bar="baz"))
+
+    def testEvalFormat(self):
+        a = [("Hello {val}", "p1")]
+        self.assertEqual(
+            q.genEventScript(a, lambda cond: dict(val="World")), "Hello World"
+        )
+
+    def testEvalBadType(self):
+        a = [("dontcare", "p1")]
+        with self.assertRaises(Exception):
+            q.genEventScript(a, lambda cond: 7)

--- a/continuousprint/automation_test.py
+++ b/continuousprint/automation_test.py
@@ -8,7 +8,7 @@ class TestInterpreter(unittest.TestCase):
         self.assertEqual(interp.symtable["a"], 1)
 
 
-class TestGenEventScript(AutomationDBTest):
+class TestGenEventScript(unittest.TestCase):
     def testEvalTrueFalseNone(self):
         a = [("gcode1", "p1")]
         self.assertEqual(genEventScript(a, lambda cond: True), "gcode1")
@@ -18,20 +18,20 @@ class TestGenEventScript(AutomationDBTest):
     def testPlaceholderNoPreprocessor(self):
         a = [("{foo} will never be formatted!", None)]
         with self.assertRaises(Exception):
-            q.genEventScript(a, lambda cond: False)
+            genEventScript(a, lambda cond: False)
 
     def testEvalMissedPlaceholder(self):
         a = [("{foo} will never be formatted!", "p1")]
         with self.assertRaises(Exception):
-            q.genEventScript(a, lambda cond: dict(bar="baz"))
+            genEventScript(a, lambda cond: dict(bar="baz"))
 
     def testEvalFormat(self):
         a = [("Hello {val}", "p1")]
         self.assertEqual(
-            q.genEventScript(a, lambda cond: dict(val="World")), "Hello World"
+            genEventScript(a, lambda cond: dict(val="World")), "Hello World"
         )
 
     def testEvalBadType(self):
         a = [("dontcare", "p1")]
         with self.assertRaises(Exception):
-            q.genEventScript(a, lambda cond: 7)
+            genEventScript(a, lambda cond: 7)

--- a/continuousprint/data/__init__.py
+++ b/continuousprint/data/__init__.py
@@ -17,55 +17,116 @@ with open(os.path.join(base, "preprocessors.yaml"), "r") as f:
     )
 
 
+# This is used for running the preprocessor simulator in the settings page.
+SIMULATOR_DEFAULT_SYMTABLE = {
+    "current": {
+        "path": "testprint.gcode",
+        "materials": ["PLA_red_#ff0000"],
+        "bed_temp": 23.59,
+        "state": "printing",
+        "action": "TICK",
+    },
+    "external": {},
+    "metadata": {
+        "hash": "123abc",
+        "analysis": {
+            "printingArea": {
+                "maxX": 3,
+                "maxY": 6,
+                "maxZ": 9,
+                "minX": -3,
+                "minY": -6,
+                "minZ": -9.0,
+            },
+            "dimensions": {"depth": 5, "height": 10, "width": 15},
+            "estimatedPrintTime": 12345,
+            "filament": {"tool0": {"length": 123, "volume": 456}},
+        },
+        "continuousprint": {"profile": "Generic"},
+        "history": [
+            {
+                "timestamp": 1234567890,
+                "printTime": 100.0,
+                "success": True,
+                "printerProfile": "_default",
+            },
+        ],
+        "statistics": {
+            "averagePrintTime": {"_default": 100.0},
+            "lastPrintTime": {"_default": 100.0},
+        },
+    },
+}
+
+
 class CustomEvents(Enum):
     ACTIVATE = (
         "continuousprint_activate",
         "Queue Activated",
         "Fires when the queue is started, e.g. via the 'Start Managing' button.",
+        "inactive",
     )
     PRINT_START = (
         "continuousprint_start_print",
         "Print Start",
         "Fires when a new print is starting from the queue. Unlike OctoPrint events, this does not fire when event scripts are executed.",
+        "idle",
     )
     PRINT_SUCCESS = (
         "continuousprint_success",
         "Print Success",
         "Fires when the active print finishes. This will also fire for prints running before the queue was started. The final print will fire QUEUE_FINISH instead of PRINT_SUCCESS.",
+        "printing",
     )
     PRINT_CANCEL = (
         "continuousprint_cancel",
         "Print Cancel",
         "Fires when automation or the user has cancelled the active print.",
+        "printing",
     )
     COOLDOWN = (
         "continuousprint_cooldown",
         "Bed Cooldown",
         "Fires when bed cooldown is starting. Bed Cooldown is disabled by default - see the settings below.",
+        "idle",
     )
     FINISH = (
         "continuousprint_finish",
         "Queue Finished",
         "Fires when there is no work left to do and the plugin goes idle.",
+        "printing",
     )
     AWAITING_MATERIAL = (
         "continuousprint_awaiting_material",
         "Awaiting Material",
         "Fires once when the current job requires a different material than what is currently loaded. This requires SpoolManager to be installed (see Integrations).",
+        "idle",
     )
     DEACTIVATE = (
         "continuousprint_deactivate",
         "Queue Deactivated",
         "Fires when the queue is no longer actively managed. This script may be skipped if another print is underway when the queue goes inactive.",
+        "idle",
     )
 
-    def __init__(self, event, displayName, desc):
+    def __init__(self, event, displayName, desc, sym_state):
         self.event = event
         self.displayName = displayName
         self.desc = desc
+        self.sym_state = sym_state
+
+    @classmethod
+    def from_event(self, k):
+        evts = dict([(e.event, e) for e in self])
+        return evts[k]
 
     def as_dict(self):
-        return dict(event=self.event, display=self.displayName, desc=self.desc)
+        return dict(
+            event=self.event,
+            display=self.displayName,
+            desc=self.desc,
+            sym_state=self.sym_state,
+        )
 
 
 class Keys(Enum):
@@ -119,6 +180,7 @@ ASSETS = dict(
         "js/continuousprint_job.js",
         "js/continuousprint_queue.js",
         "js/continuousprint_viewmodel.js",
+        "js/continuousprint_settings_event.js",
         "js/continuousprint_settings.js",
         "js/continuousprint.js",
     ],

--- a/continuousprint/script_runner.py
+++ b/continuousprint/script_runner.py
@@ -7,7 +7,8 @@ from octoprint.printer import InvalidFileLocation, InvalidFileType
 from octoprint.server import current_user
 from .storage.lan import ResolveError
 from .data import TEMP_FILE_DIR, CustomEvents
-from .storage.queries import genEventScript, getInterpreter, getAutomationForEvent
+from .storage.queries import getAutomationForEvent
+from .automation import genEventScript, getInterpreter
 
 
 class ScriptRunner:

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -342,7 +342,7 @@
   font-weight: italic;
   opacity: 0.7;
 }
-#tab_plugin_continuousprint .hint {
+#tab_plugin_continuousprint, #settings_plugin_continuousprint .hint {
   font-weight: italic;
   font-size: 85%;
   opacity: 0.7;

--- a/continuousprint/static/css/continuousprint.css
+++ b/continuousprint/static/css/continuousprint.css
@@ -281,6 +281,30 @@
   margin-top: var(--cpq-pad2);
   padding-top: var(--cpq-pad2);
 }
+#settings_plugin_continuousprint .simulation-output {
+  display:flex;
+  flex-direction: row;
+  justify-content: center;
+}
+#settings_plugin_continuousprint .simulation-output > div {
+  flex: 1;
+  padding: var(--cpq-pad);
+}
+#settings_plugin_continuousprint .simulation-output h5 {
+  margin: 0;
+  text-align: center;
+  opacity: 0.5;
+}
+#settings_plugin_continuousprint .output-block {
+  border: 1px #e5e5e5 solid; /* copy from .accordion-group */
+	border-radius: var(--cpq-pad);
+  width: 100%;
+  min-height: 150px;
+  max-height: 400px;
+  overflow-y: scroll;
+  padding: 0;
+  margin: 0;
+}
 #tab_plugin_continuousprint .queue-header, #settings_continuousprint_queues .queue-header {
   display: flex;
   justify-content: space-between;

--- a/continuousprint/static/js/continuousprint_api.js
+++ b/continuousprint/static/js/continuousprint_api.js
@@ -101,6 +101,9 @@ class CPAPI {
     this._call_base(`${this.BASE}/set_active`, {active}, cb);
   }
 
+  simulate(automation, symtable, cb, err_cb) {
+    this._call(this.AUTOMATION, 'simulate', {symtable: JSON.stringify(symtable), automation: JSON.stringify(automation)}, cb, err_cb, false);
+  }
 }
 
 try {

--- a/continuousprint/static/js/continuousprint_settings.js
+++ b/continuousprint/static/js/continuousprint_settings.js
@@ -372,19 +372,9 @@ function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_s
       }
       let events = {};
       for (let e of self.events()) {
-        let ks = [];
-        for (let a of e.actions()) {
-          let pp = a.preprocessor();
-          if (pp !== null) {
-            pp = pp.name();
-          }
-          ks.push({
-            script: a.script.name(),
-            preprocessor: pp,
-          });
-        }
-        if (ks.length !== 0) {
-          events[e.event] = ks;
+        let e2 = e.pack();
+        if (e2) {
+          events[e.event] = e2;
         }
       }
       let data = {scripts, preprocessors, events};

--- a/continuousprint/static/js/continuousprint_settings.js
+++ b/continuousprint/static/js/continuousprint_settings.js
@@ -343,10 +343,7 @@ function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_s
               preprocessor: ko.observable(preprocessors[a.preprocessor]),
             });
           }
-          events.push({
-            ...k,
-            actions: ko.observableArray(actions),
-          });
+          events.push(new CPSettingsEvent(k, actions, self.api));
         }
         events.sort((a, b) => a.display < b.display);
         self.events(events);
@@ -377,7 +374,7 @@ function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_s
       for (let e of self.events()) {
         let ks = [];
         for (let a of e.actions()) {
-          let pp = a.preprocessor()
+          let pp = a.preprocessor();
           if (pp !== null) {
             pp = pp.name();
           }

--- a/continuousprint/static/js/continuousprint_settings.js
+++ b/continuousprint/static/js/continuousprint_settings.js
@@ -9,9 +9,11 @@ if (typeof log === "undefined" || log === null) {
   CP_CUSTOM_EVENTS = [];
   CP_LOCAL_IP = '';
   CPAPI = require('./continuousprint_api');
+  CP_SIMULATOR_DEFAULT_SYMTABLE = function() {return {};};
+  CPSettingsEvent = require('./continuousprint_settings_event');
 }
 
-function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_scripts=CP_GCODE_SCRIPTS, custom_events=CP_CUSTOM_EVENTS) {
+function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_scripts=CP_GCODE_SCRIPTS, custom_events=CP_CUSTOM_EVENTS, default_symtable=CP_SIMULATOR_DEFAULT_SYMTABLE) {
     var self = this;
     self.PLUGIN_ID = "octoprint.plugins.continuousprint";
     self.log = log.getLogger(self.PLUGIN_ID);
@@ -343,7 +345,7 @@ function CPSettingsViewModel(parameters, profiles=CP_PRINTER_PROFILES, default_s
               preprocessor: ko.observable(preprocessors[a.preprocessor]),
             });
           }
-          events.push(new CPSettingsEvent(k, actions, self.api));
+          events.push(new CPSettingsEvent(k, actions, self.api, default_symtable()));
         }
         events.sort((a, b) => a.display < b.display);
         self.events(events);

--- a/continuousprint/static/js/continuousprint_settings.test.js
+++ b/continuousprint/static/js/continuousprint_settings.test.js
@@ -61,6 +61,7 @@ function mocks() {
       init: jest.fn(),
       get: jest.fn((_, cb) => cb([])),
       edit: jest.fn(),
+      simulate: jest.fn(),
     },
   ];
 }

--- a/continuousprint/static/js/continuousprint_settings_event.js
+++ b/continuousprint/static/js/continuousprint_settings_event.js
@@ -1,0 +1,86 @@
+if (typeof log === "undefined" || log === null) {
+  // In the testing environment, dependencies must be manually imported
+  ko = require('knockout');
+  log = {
+    "getLogger": () => {return console;}
+  };
+  CP_PRINTER_PROFILES = [];
+  CP_GCODE_SCRIPTS = [];
+  CP_CUSTOM_EVENTS = [];
+  CP_LOCAL_IP = '';
+  CPAPI = require('./continuousprint_api');
+}
+
+function CPSettingsEvent(evt, actions, api) {
+    var self = this;
+    self.api = api;
+    self.name = evt.name;
+    self.display = evt.display;
+    self.desc = evt.desc;
+
+    // Construct symtable used for simulating output
+    let sym = CP_SIMULATOR_DEFAULT_SYMTABLE();
+    sym.current.state = evt.sym_state;
+    self.symtable = ko.observable(sym);
+
+    // actions is an array of {script, preprocessor (observable)}
+    self.actions = ko.observableArray(actions);
+
+    self.timeout = null;
+    self.running = ko.observable(false);
+    self.simulation = ko.observable(null);
+    self.updater = ko.computed(function() {
+      // Computed function doesn't return anything itself, but does
+      // update the simulation observable abovself.
+      // We operate after a timeout so as not to send unnecessary load
+      // to the server.
+      self.running(true);
+      if (self.timeout !== null) {
+        clearTimeout(self.timeout);
+      }
+      self.timeout = setTimeout(function() {
+        automation = [];
+        for (let a of self.actions()) {
+          let pp = a.preprocessor();
+          automation.push([
+            a.script.body(),
+            (pp && pp.body())
+          ]);
+        }
+        console.log("simUpdater", self.name, automation, self.symtable());
+        self.api.simulate(automation, self.symtable(), (result) => {
+          self.simulation(result);
+          self.timeout = null;
+          self.running(false);
+        }, (err) => {
+          console.error(err);
+          self.simulation(err);
+          self.timeout = null;
+          self.running(false);
+        });
+      }, 1000);
+    });
+
+    self.prep_for_submit = function() {
+      let ks = [];
+      for (let a of self.actions()) {
+        let pp = a.preprocessor();
+        if (pp !== null) {
+          pp = pp.name();
+        }
+        ks.push({
+          script: a.script.name(),
+          preprocessor: pp,
+        });
+      }
+      if (ks.length !== 0) {
+        events[self.event] = ks;
+      }
+    };
+}
+
+try {
+module.exports = {
+  CPSettingsEvent,
+};
+} catch {}

--- a/continuousprint/static/js/continuousprint_settings_event.js
+++ b/continuousprint/static/js/continuousprint_settings_event.js
@@ -11,7 +11,7 @@ if (typeof log === "undefined" || log === null) {
   CPAPI = require('./continuousprint_api');
 }
 
-function CPSettingsEvent(evt, actions, api) {
+function CPSettingsEvent(evt, actions, api, default_symtable) {
     var self = this;
     self.api = api;
     self.name = evt.name;
@@ -20,8 +20,10 @@ function CPSettingsEvent(evt, actions, api) {
     self.desc = evt.desc;
 
     // Construct symtable used for simulating output
-    let sym = CP_SIMULATOR_DEFAULT_SYMTABLE();
-    sym.current.state = evt.sym_state;
+    let sym = default_symtable;
+    if (sym.current) {
+      sym.current.state = evt.sym_state;
+    }
     self.symtable = ko.observable(sym);
     self.symtableEdit = ko.observable(JSON.stringify(sym, null, 2));
     self.symtableEditError = ko.observable(null);
@@ -109,7 +111,6 @@ function CPSettingsEvent(evt, actions, api) {
     self.simExpanded = ko.observable(true);
     self.symtableExpanded = ko.observable(true);
     self.updater = ko.computed(function() {
-      console.log("updater()");
       // Computed function doesn't return anything itself, but does
       // update the simulation observable above. It does need to be
       // referenced from the HTML though.
@@ -133,7 +134,6 @@ function CPSettingsEvent(evt, actions, api) {
         clearTimeout(self.timeout);
       }
       self.timeout = setTimeout(function() {
-        console.log("simUpdater", self.name, automation, sym);
         self.api.simulate(automation, sym, (result) => {
           self.simulation(result);
           self.timeout = null;
@@ -166,7 +166,5 @@ function CPSettingsEvent(evt, actions, api) {
 }
 
 try {
-module.exports = {
-  CPSettingsEvent,
-};
+module.exports = CPSettingsEvent;
 } catch {}

--- a/continuousprint/static/js/continuousprint_settings_event.js
+++ b/continuousprint/static/js/continuousprint_settings_event.js
@@ -15,6 +15,7 @@ function CPSettingsEvent(evt, actions, api) {
     var self = this;
     self.api = api;
     self.name = evt.name;
+    self.event = evt.event;
     self.display = evt.display;
     self.desc = evt.desc;
 
@@ -97,8 +98,12 @@ function CPSettingsEvent(evt, actions, api) {
         return "Simulation: execution error!";
       }
       let r = "Simulation OK: ";
-      r += `${numlines(s.gcode)} lines, `;
-      r += `${numlines(s.stdout)} notifications`;
+      let gline = numlines(s.gcode);
+      r += (gline === 1) ? '1 line' : `${gline} lines`;
+      let nline = numlines(s.stdout);
+      if (nline > 0) {
+        r += (nline === 1) ? ', 1 notification' : `, ${nline} notifications`;
+      }
       return r;
     });
     self.simExpanded = ko.observable(true);
@@ -142,7 +147,7 @@ function CPSettingsEvent(evt, actions, api) {
       }, 1000);
     });
 
-    self.prep_for_submit = function() {
+    self.pack = function() {
       let ks = [];
       for (let a of self.actions()) {
         let pp = a.preprocessor();
@@ -155,7 +160,7 @@ function CPSettingsEvent(evt, actions, api) {
         });
       }
       if (ks.length !== 0) {
-        events[self.event] = ks;
+        return ks;
       }
     };
 }

--- a/continuousprint/static/js/continuousprint_settings_event.js
+++ b/continuousprint/static/js/continuousprint_settings_event.js
@@ -63,7 +63,7 @@ function CPSettingsEvent(evt, actions, api, default_symtable) {
       if (self.running()) {
         return "...";
       }
-      return s.stdout + s.stderr;
+      return s.stdout + '\n' + s.stderr;
     });
     self.simSymtable = ko.computed(function() {
       let s = self.simulation();
@@ -138,9 +138,15 @@ function CPSettingsEvent(evt, actions, api, default_symtable) {
           self.simulation(result);
           self.timeout = null;
           self.running(false);
-        }, (err) => {
-          console.error(err);
-          self.simulation(err);
+        }, (code, reason) => {
+          let msg = `Server error (${code}): ${reason}`;
+          console.error(msg);
+          self.simulation({
+            gcode: '',
+            stdout: '',
+            stderr: msg,
+            symtable_diff: [],
+          });
           self.timeout = null;
           self.running(false);
         });

--- a/continuousprint/static/js/continuousprint_settings_event.test.js
+++ b/continuousprint/static/js/continuousprint_settings_event.test.js
@@ -1,0 +1,122 @@
+const CPSettingsEvent = require('./continuousprint_settings_event');
+
+function testAction(n, gcode, py) {
+  return {
+    script: {name: ko.observable('s' + n), body: ko.observable(gcode)},
+    preprocessor: ko.observable({name: ko.observable('p' + n), body: ko.observable(py)}),
+  }
+}
+
+function testEvent() {
+  return new CPSettingsEvent(
+    {name: 'name', event: 'event', display: 'display', desc: 'desc', sym_state: 'evt_state'},
+    [testAction(0, "g1", "p1"), testAction(1, "g2", "p2")],
+    {simulate: jest.fn()},
+    {defaultsym: 'asdf'}
+  );
+}
+
+describe('visible text computed vars', () => {
+  test('sim running', () => {
+    let vm = testEvent();
+    vm.running(true);
+
+    expect(vm.simGcodeOutput()).toEqual("...");
+    expect(vm.combinedSimOutput()).toEqual("...");
+    expect(vm.simSymtable()).toEqual([]);
+    expect(vm.simSummary()).toEqual("running simulation...");
+  });
+  test('sim successful', () => {
+    // TODO simGcodeOutput, combinedSimOutput, simSymtable, simSummary
+    let vm = testEvent();
+    vm.simulation({
+      gcode: "gcode",
+      stdout: "stdout",
+      stderr: "",
+      symtable_diff: {a: 'foo'},
+    });
+    vm.running(false);
+
+    expect(vm.simGcodeOutput()).toEqual("gcode");
+    expect(vm.combinedSimOutput()).toEqual("stdout\n");
+    expect(vm.simSymtable()).toEqual([{key: 'a', value: 'foo'}]);
+    expect(vm.simSummary()).toEqual("Simulation OK: 1 line, 1 notification");
+  });
+  test('sim error', () => {
+    // TODO simGcodeOutput, combinedSimOutput, simSymtable, simSummary
+    let vm = testEvent();
+    vm.simulation({
+      gcode: "gcode ignored",
+      stdout: "stdout",
+      stderr: "stderr",
+      symtable_diff: {a: 'foo'},
+    });
+    vm.running(false);
+
+    expect(vm.simGcodeOutput()).toEqual("@PAUSE; Preprocessor error");
+    expect(vm.combinedSimOutput()).toEqual("stdout\nstderr");
+    expect(vm.simSymtable()).toEqual([{key: 'a', value: 'foo'}]);
+    expect(vm.simSummary()).toEqual("Simulation: execution error!");
+  });
+});
+
+describe('symtableEdit', () => {
+  test('updates symtable when symtableEdit edited successfully', () => {
+    let vm = testEvent();
+    vm.symtableEdit("123");
+    expect(vm.symtable()).toEqual(123);
+  });
+  test('updates symtableEditError when JSON parse fails', () => {
+    let vm = testEvent();
+    vm.symtableEdit("not parseable");
+    expect(vm.symtableEditError()).toMatch(/^SyntaxError.*/);
+  });
+});
+
+describe('updater', () => {
+  test('updates simulation values exactly once', () => {
+    jest.useFakeTimers();
+    let vm = testEvent();
+    let want = {symtable_diff: [], gcode: "result", stdout: "", stderr: ""};
+    vm.api.simulate = jest.fn((auto, sym, cb, errcb) => {
+      cb(want);
+    });
+    vm.actions(vm.actions()); // Set dirty bit
+    vm.updater();
+    expect(vm.timer).not.toEqual(null);
+    expect(vm.running()).toEqual(true);
+
+    // Trigger updater a couple more times for good measure
+    for (let i = 0; i < 10; i++) {
+      vm.actions(vm.actions()); // Set dirty bit
+      vm.updater();
+    }
+
+    jest.runAllTimers();
+    expect(vm.api.simulate).toHaveBeenCalledTimes(1);
+
+    expect(vm.running()).toEqual(false);
+    expect(vm.simulation()).toEqual(want);
+  });
+  test('handles server error', () => {
+    jest.useFakeTimers();
+    let vm = testEvent();
+    let want = {symtable_diff: [], gcode: "result", stdout: "", stderr: ""};
+    vm.api.simulate = jest.fn((auto, sym, cb, errcb) => {
+      errcb(123, "test");
+    });
+    vm.actions(vm.actions()); // Set dirty bit
+    vm.updater();
+    jest.runAllTimers();
+    expect(vm.running()).toEqual(false);
+    expect(vm.simulation().stderr).toEqual('Server error (123): test');
+  });
+});
+
+test('pack', () => {
+  let vm = testEvent();
+  expect(vm.pack()).toEqual([
+    {"preprocessor": "p0", "script": "s0"},
+    {"preprocessor": "p1", "script": "s1"}
+  ]);
+});

--- a/continuousprint/static/js/continuousprint_settings_event.test.js
+++ b/continuousprint/static/js/continuousprint_settings_event.test.js
@@ -27,7 +27,6 @@ describe('visible text computed vars', () => {
     expect(vm.simSummary()).toEqual("running simulation...");
   });
   test('sim successful', () => {
-    // TODO simGcodeOutput, combinedSimOutput, simSymtable, simSummary
     let vm = testEvent();
     vm.simulation({
       gcode: "gcode",
@@ -43,7 +42,6 @@ describe('visible text computed vars', () => {
     expect(vm.simSummary()).toEqual("Simulation OK: 1 line, 1 notification");
   });
   test('sim error', () => {
-    // TODO simGcodeOutput, combinedSimOutput, simSymtable, simSummary
     let vm = testEvent();
     vm.simulation({
       gcode: "gcode ignored",

--- a/continuousprint/storage/queries.py
+++ b/continuousprint/storage/queries.py
@@ -501,7 +501,7 @@ def getAutomation():
 
 def getAutomationForEvent(evt: CustomEvents) -> list:
     return [
-        (e.script.body, e.preprocessor.body)
+        (e.script.body, e.preprocessor.body if e.preprocessor else None)
         for e in (
             EventHook.select()
             .join_from(EventHook, Script, JOIN.LEFT_OUTER)

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -380,7 +380,7 @@ class TestAutomation(AutomationDBTest):
         self.assertEqual(got["events"][evt], [dict(script="foo", preprocessor=None)])
 
     def testAssignBadEventKey(self):
-        with self.assertRaisesRegexp(KeyError, "No such CPQ event"):
+        with self.assertRaisesRegex(KeyError, "No such CPQ event"):
             q.assignAutomation(
                 dict(), dict(), dict(evt=[dict(script="foo", preprocessor=None)])
             )
@@ -393,7 +393,6 @@ class TestAutomation(AutomationDBTest):
             )
 
     def testMultiScriptEvent(self):
-        raise Exception("TODO convert to getAutomationForevent")
         evt = CustomEvents.PRINT_SUCCESS.event
         q.assignAutomation(
             dict(s1="gcode1", s2="gcode2"),
@@ -410,7 +409,10 @@ class TestAutomation(AutomationDBTest):
                 ]
             ),
         )
-        self.assertEqual(q.genEventScript(CustomEvents.PRINT_SUCCESS), "gcode1\ngcode2")
+        self.assertEqual(
+            [a[0] for a in q.getAutomationForEvent(CustomEvents.PRINT_SUCCESS)],
+            ["gcode1", "gcode2"],
+        )
 
         # Ordering of event matters
         q.assignAutomation(
@@ -428,4 +430,7 @@ class TestAutomation(AutomationDBTest):
                 ]
             ),
         )
-        self.assertEqual(q.genEventScript(CustomEvents.PRINT_SUCCESS), "gcode2\ngcode1")
+        self.assertEqual(
+            [a[0] for a in q.getAutomationForEvent(CustomEvents.PRINT_SUCCESS)],
+            ["gcode2", "gcode1"],
+        )

--- a/continuousprint/storage/queries_test.py
+++ b/continuousprint/storage/queries_test.py
@@ -393,6 +393,7 @@ class TestAutomation(AutomationDBTest):
             )
 
     def testMultiScriptEvent(self):
+        raise Exception("TODO convert to getAutomationForevent")
         evt = CustomEvents.PRINT_SUCCESS.event
         q.assignAutomation(
             dict(s1="gcode1", s2="gcode2"),
@@ -428,56 +429,3 @@ class TestAutomation(AutomationDBTest):
             ),
         )
         self.assertEqual(q.genEventScript(CustomEvents.PRINT_SUCCESS), "gcode2\ngcode1")
-
-    def testPreprocessorEvalTrueFalseNone(self):
-        e = CustomEvents.PRINT_SUCCESS
-        q.assignAutomation(
-            dict(s1="gcode1"),
-            dict(p1="python1"),
-            dict([(e.event, [dict(script="s1", preprocessor="p1")])]),
-        )
-
-        self.assertEqual(q.genEventScript(e, lambda cond: True), "gcode1")
-        self.assertEqual(q.genEventScript(e, lambda cond: False), "")
-        self.assertEqual(q.genEventScript(e, lambda cond: None), "")
-
-    def testNoProcessorPlaceholder(self):
-        e = CustomEvents.PRINT_SUCCESS
-        q.assignAutomation(
-            dict(s1="{foo} will never be formatted!"),
-            dict(),
-            dict([(e.event, [dict(script="s1", preprocessor=None)])]),
-        )
-        with self.assertRaises(Exception):
-            q.genEventScript(e, lambda cond: False)
-
-    def testProcessorEvalFormat(self):
-        e = CustomEvents.PRINT_SUCCESS
-        q.assignAutomation(
-            dict(s1="Hello {val}"),
-            dict(p1="mocked"),
-            dict([(e.event, [dict(script="s1", preprocessor="p1")])]),
-        )
-        self.assertEqual(
-            q.genEventScript(e, lambda cond: dict(val="World")), "Hello World"
-        )
-
-    def testProcessorEvalBadType(self):
-        e = CustomEvents.PRINT_SUCCESS
-        q.assignAutomation(
-            dict(s1="don'tcare"),
-            dict(p1="mocked"),
-            dict([(e.event, [dict(script="s1", preprocessor="p1")])]),
-        )
-        with self.assertRaises(Exception):
-            q.genEventScript(e, lambda cond: 7)
-
-    def testProcessorEvalMissedPlaceholder(self):
-        e = CustomEvents.PRINT_SUCCESS
-        q.assignAutomation(
-            dict(s1="{foo} will never be formatted!"),
-            dict(p1="mocked"),
-            dict([(e.event, [dict(script="s1", preprocessor="p1")])]),
-        )
-        with self.assertRaises(Exception):
-            q.genEventScript(e, lambda cond: dict(bar="baz"))

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -9,6 +9,7 @@
   const CP_CUSTOM_EVENTS = {{plugin_continuousprint_custom_events|tojson|safe}};
   const CP_LOCAL_IP = {{plugin_continuousprint_local_ip|tojson|safe}};
   const CP_EXCEPTIONS = {{plugin_continuousprint_exceptions|tojson|safe}};
+  const CP_SIMULATOR_DEFAULT_SYMTABLE = function() {return {{plugin_continuousprint_simulator_default_symtable|tojson|safe}}; };
 </script>
 
 <ul id="settings_continuousprint_tabs" class="nav nav-pills">
@@ -101,6 +102,9 @@
           </div>
         </div> <!-- foreach actions -->
 
+        <div class="simulation">
+        <div data-bind="text: JSON.stringify(simulation())"></div>
+        </div>
 
         <div class="dropdown pull-right" style="width: 120px">
           <a class="btn dropdown-toggle" data-toggle="dropdown">

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -107,7 +107,7 @@
           This hidden element needed for rendering simulation() results;
           see CPSettingsEvent class
         </span>
-        <div class="accordion-group">
+        <div class="accordion-group" data-bind="visible: actions().length > 0">
           <div class="accordion-heading" data-bind="click: simExpanded(!simExpanded())" style="cursor:pointer">
             <i class="fa" data-bind="css: simExpanded() ? 'fa-caret-down' : 'fa-caret-right'"></i>
             <div style="display:inline; margin-left: 5px" data-bind="text: simSummary"></div>
@@ -124,15 +124,21 @@
                   <pre class="output-block" data-bind="text: combinedSimOutput"></pre>
                 </div>
               </div>
-              <a style="text-align: center; display: block;" href="#" data-bind="click: symtableExpanded(!symtableExpanded())">toggle symtable details</a>
+              <a style="text-align: center; display: block;" href="#" data-bind="click: symtableExpanded(!symtableExpanded())">toggle state details</a>
               <div data-bind="visible: symtableExpanded">
-                <h5>Modified symbols</h5>
+                <h5>Modified state</h5>
+                <div class="hint" data-bind="visible: simSymtable().length > 0">
+                  Hint: these variables were modified by preprocessors during the simulation.
+                </div>
                 <div data-bind="visible: simSymtable().length === 0">None</div>
                 <div data-bind="foreach: simSymtable">
                   <div><span data-bind="text: key"></span> = <span data-bind="text: value"></span></div>
                 </div>
-                <h5>Symtable</h5>
-                <div data-bind="visible: symtableEditError, text: symtableEditError"></div>
+                <h5>Simulation initial state</h5>
+                <div class="hint">
+                  Hint: edit to simulate behavior with different states of the printer, file etc. - this has no effect when the event is fired for real.
+                </div>
+                <div class="alert alert-error" data-bind="visible: symtableEditError, text: symtableEditError"></div>
                 <textarea style="width:100%; min-height: 50vh" data-bind="value: symtableEdit"></textarea>
               </div>
             </div>  <!-- /accordion-inner -->

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -102,9 +102,42 @@
           </div>
         </div> <!-- foreach actions -->
 
-        <div class="simulation">
-        <div data-bind="text: JSON.stringify(simulation())"></div>
-        </div>
+
+        <span stye="height:0px; width:0px;" data-bind="text: updater">
+          This hidden element needed for rendering simulation() results;
+          see CPSettingsEvent class
+        </span>
+        <div class="accordion-group">
+          <div class="accordion-heading" data-bind="click: simExpanded(!simExpanded())" style="cursor:pointer">
+            <i class="fa" data-bind="css: simExpanded() ? 'fa-caret-down' : 'fa-caret-right'"></i>
+            <div style="display:inline; margin-left: 5px" data-bind="text: simSummary"></div>
+          </div>
+          <div class="accordion-body collapse" data-bind="css: {'in': simExpanded}">
+            <div class="accordion-inner">
+              <div class="simulation-output">
+                <div>
+                  <h5>GCODE</h5>
+                  <pre class="output-block" data-bind="text: simGcodeOutput"></pre>
+                </div>
+                <div>
+                  <h5>Notifications & Errors</h5>
+                  <pre class="output-block" data-bind="text: combinedSimOutput"></pre>
+                </div>
+              </div>
+              <a style="text-align: center; display: block;" href="#" data-bind="click: symtableExpanded(!symtableExpanded())">toggle symtable details</a>
+              <div data-bind="visible: symtableExpanded">
+                <h5>Modified symbols</h5>
+                <div data-bind="visible: simSymtable().length === 0">None</div>
+                <div data-bind="foreach: simSymtable">
+                  <div><span data-bind="text: key"></span> = <span data-bind="text: value"></span></div>
+                </div>
+                <h5>Symtable</h5>
+                <div data-bind="visible: symtableEditError, text: symtableEditError"></div>
+                <textarea style="width:100%; min-height: 50vh" data-bind="value: symtableEdit"></textarea>
+              </div>
+            </div>  <!-- /accordion-inner -->
+          </div> <!-- /accordion-body -->
+        </div> <!-- /accordion-group -->
 
         <div class="dropdown pull-right" style="width: 120px">
           <a class="btn dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
#190

This PR introduces a preview of changes to CPQ event changes in the settings dialog. 

* [x] Separate ASTEval code from script_runner so it can be run out of band
* [x] Extend API to include an endpoint for running simulations 
* [x] Refactor event objects in settings into a new JS viewmodel
* Visually confirm simulation output is re-run exactly once, when
  * [x] A script's preprocessor changes
  * [x] Scripts are reordered
  * [x] A script is added
  * [x] A new script / preprocessor is created
  * [x] The body of a script changes
  * [x] The body of a preprocessor changes
* [x] Create simple UI elements showing the script outputs (expandable)
* [x] Extend UI to also show modified symtable values
* [x] Extend UI to allow modifying initial state
* [x] UX: pluralize simulation result counts and leave off notifications if 0
* [x] Move ASTEval methods from `storage/queries.py` to their own independent file, with tests
* [x] Visually confirm settings can still be saved and loaded
* [x] Fix existing tests that are broken
* [x] Hide simulator output if the event has no scripts attached
* [x] Add unit tests ensuring above calls happen