### PR TITLE
Compute stats for whole queues

### DIFF
--- a/continuousprint/data/__init__.py
+++ b/continuousprint/data/__init__.py
@@ -177,6 +177,7 @@ ASSETS = dict(
         "js/continuousprint_api.js",
         "js/continuousprint_history_row.js",
         "js/continuousprint_set.js",
+        "js/continuousprint_stats.js",
         "js/continuousprint_job.js",
         "js/continuousprint_queue.js",
         "js/continuousprint_viewmodel.js",

--- a/continuousprint/static/js/continuousprint_job.js
+++ b/continuousprint/static/js/continuousprint_job.js
@@ -11,6 +11,9 @@ if (typeof ko === "undefined" || ko === null) {
 if (typeof CPSet === "undefined" || CPSet === null) {
   CPSet = require('./continuousprint_set');
 }
+if (typeof CPStats === "undefined" || CPStats === null) {
+  CPStats = require('./continuousprint_stats');
+}
 
 // jobs and sets are derived from self.queue, but they must be
 // observableArrays in order for Sortable to be able to reorder it.
@@ -113,42 +116,6 @@ function CPJob(obj, peers, api, profile, materials) {
     api.edit(api.JOB, data, self._update);
   }
 
-  self._safeParse = function(v) {
-    v = parseInt(v, 10);
-    if (isNaN(v)) {
-      return 0;
-    }
-    return v;
-  }
-
-
-  self.humanize = function(num, unit="") {
-    // Humanizes numbers by condensing and adding units
-    let v = '';
-    if (num < 1000) {
-      v = (num % 1 === 0) ? num : num.toFixed(1);
-    } else if (num < 100000) {
-      let k = (num/1000);
-      v = ((k % 1 === 0) ? k : k.toFixed(1)) + 'k';
-    }
-    return v + unit;
-  };
-
-  self.humanTime = function(s) {
-    // Humanizes time values; parameter is seconds
-    if (s < 60) {
-      return Math.round(s) + 's';
-    } else if (s < 3600) {
-      return Math.round(s/60) + 'm';
-    } else if (s < 86400) {
-      let h = s/3600;
-      return ((h % 1 === 0) ? h : h.toFixed(1)) + 'h';
-    } else {
-      let d = s/86400;
-      return ((d % 1 === 0) ? d : d.toFixed(1)) + 'd';
-    }
-  };
-
   self.getMaterialLinearMasses = ko.computed(function() {
     let result = [];
     for (let m of materials()) {
@@ -162,101 +129,8 @@ function CPJob(obj, peers, api, profile, materials) {
     return result;
   });
 
-  self.raw_stats = ko.computed(function() {
-    let result = {completed: 0, remaining: 0, count: 0};
-    for (let qs of self.sets()) {
-      if (!qs.profile_matches()) {
-        continue;
-      }
-      result.remaining += self._safeParse(qs.remaining());
-      result.count += self._safeParse(qs.count());
-      result.completed += self._safeParse(qs.completed());
-    }
-    return result;
-  });
-
   self.totals = ko.computed(function() {
-    let r = [
-      {legend: 'Total items', title: null},
-      {legend: 'Total time', title: "Uses Octoprint's file analysis estimate; may be inaccurate"},
-      {legend: 'Total mass', title: "Mass is calculated using active spool(s) in SpoolManager"},
-    ];
-
-    let linmasses = self.getMaterialLinearMasses();
-
-    for (let t of r) {
-      t.count = 0;
-      t.completed = 0;
-      t.remaining = 0;
-      t.total = 0;
-      t.error = 0;
-    }
-
-    for (let qs of self.sets()) {
-      if (!qs.profile_matches()) {
-        continue;
-      }
-
-      let rem = self._safeParse(qs.remaining())
-      let tot = self._safeParse(qs.length_remaining());
-      let count = self._safeParse(qs.count());
-      let cplt = self._safeParse(qs.completed());
-
-      let meta = qs.metadata;
-      let ept = meta && meta.estimatedPrintTime
-      let len = meta && meta.filamentLengths;
-
-      // Update print count totals
-      r[0].remaining += rem;
-      r[0].total += tot;
-      r[0].count += count;
-      r[0].completed += cplt;
-
-      if (ept === null || ept === undefined) {
-        r[1].error += 1;
-      } else {
-        r[1].remaining += rem * ept;
-        r[1].total += tot * ept
-        r[1].count += count * ept;
-        r[1].completed += cplt * ept;
-      }
-
-      if (len === null || len === undefined || len.length === 0) {
-        r[2].error += 1;
-      } else {
-        let mass = 0;
-        for (let i = 0; i < len.length; i++) {
-          mass += linmasses[i] * len[i];
-        }
-
-        if (!isNaN(mass)) {
-          r[2].remaining += rem * mass;
-          r[2].total += tot * mass;
-          r[2].count += count * mass;
-          r[2].completed += cplt * mass;
-        } else {
-          r[2].error += 1;
-        }
-      }
-
-    }
-    // Assign error texts
-    r[0].error = '';
-    r[1].error = (r[1].error > 0) ? `${r[1].error} sets missing time estimates` : '';
-    r[2].error = (r[2].error > 0) ? `${r[1].error} errors calculating mass` : '';
-
-    for (let k of ['remaining', 'total', 'count', 'completed']) {
-      r[0][k] = self.humanize(r[0][k]);
-      r[1][k] = self.humanTime(r[1][k]);
-      r[2][k] = self.humanize(r[2][k], 'g');
-    }
-
-    // Hide mass details if linmasses is empty (implies SpoolManager not set up)
-    if (linmasses.length === 0) {
-      r.splice(2,1);
-    }
-
-    return r;
+    return new CPStats(() => [self]);
   });
 
   self.checkFraction = ko.computed(function() {

--- a/continuousprint/static/js/continuousprint_job.js
+++ b/continuousprint/static/js/continuousprint_job.js
@@ -10,14 +10,18 @@ if (typeof ko === "undefined" || ko === null) {
 }
 if (typeof CPSet === "undefined" || CPSet === null) {
   CPSet = require('./continuousprint_set');
-}
-if (typeof CPStats === "undefined" || CPStats === null) {
   CPStats = require('./continuousprint_stats');
+  CP_STATS_DIMENSIONS={
+    completed: null,
+    count: null,
+    remaining: null,
+    total: null,
+  };
 }
 
 // jobs and sets are derived from self.queue, but they must be
 // observableArrays in order for Sortable to be able to reorder it.
-function CPJob(obj, peers, api, profile, materials) {
+function CPJob(obj, peers, api, profile, materials, stats_dimensions=CP_STATS_DIMENSIONS) {
   if (api === undefined) {
     throw Error("API must be provided when creating CPJob");
   }
@@ -130,7 +134,7 @@ function CPJob(obj, peers, api, profile, materials) {
   });
 
   self.totals = ko.computed(function() {
-    return new CPStats(() => [self]);
+    return new CPStats(() => [self], stats_dimensions);
   });
 
   self.checkFraction = ko.computed(function() {

--- a/continuousprint/static/js/continuousprint_job.test.js
+++ b/continuousprint/static/js/continuousprint_job.test.js
@@ -52,9 +52,11 @@ test('onSetModified existing', () => {
 });
 
 test('totals', () => {
-  let j = new Job({count: 3, completed: 2, remaining: 1, sets: sets()}, [], api(), prof(), mats());
+  let j = new Job({
+    count: 3, completed: 2, remaining: 1, sets: sets()
+  }, [], api(), prof(), mats());
 
-  let t = j.totals();
+  let t = j.totals().values_humanized();
   expect(t[0]).toStrictEqual({
     completed: "2", // sets have 1/2 completed this run
     count: "4", // 2 sets each with count=2

--- a/continuousprint/static/js/continuousprint_queue.js
+++ b/continuousprint/static/js/continuousprint_queue.js
@@ -9,6 +9,7 @@ if (typeof CPJob === "undefined" || CPJob === null) {
   // In the testing environment, dependencies must be manually imported
   ko = require('knockout');
   CPJob = require('./continuousprint_job');
+  CPStats = require('./continuousprint_stats');
   log = {
     "getLogger": () => {return console;}
   };
@@ -95,18 +96,20 @@ function CPQueue(data, api, files, profile, materials) {
           break;
         case "Unstarted Jobs":
           for (let j of self.jobs()) {
-            j.onChecked(j.sets().length !== 0 && j.raw_stats().completed === 0);
+            let t = j.totals().values()[0];
+            j.onChecked(j.sets().length !== 0 && t.completed === 0);
           }
           break;
         case "Incomplete Jobs":
           for (let j of self.jobs()) {
-            let t = j.raw_stats();
+            let t = j.totals().values()[0];
             j.onChecked(t.remaining > 0 && t.remaining < t.count);
           }
           break;
         case "Completed Jobs":
           for (let j of self.jobs()) {
-            j.onChecked(j.sets().length !== 0 && j.raw_stats().remaining == 0);
+            let t = j.totals().values()[0];
+            j.onChecked(j.sets().length !== 0 && t.remaining == 0);
           }
           break;
         default:
@@ -157,6 +160,10 @@ function CPQueue(data, api, files, profile, materials) {
       }
       e.preventDefault();
     }
+
+    self.totals = ko.computed(function() {
+      return new CPStats(self.jobs);
+    });
 
     // *** ko template methods ***
     self._getSelections = function() {

--- a/continuousprint/static/js/continuousprint_queue.js
+++ b/continuousprint/static/js/continuousprint_queue.js
@@ -32,6 +32,7 @@ function CPQueue(data, api, files, profile, materials) {
     self.shiftsel = ko.observable(-1);
     self.details = ko.observable("");
     self.fullDetails = ko.observable("");
+    self.showStats = ko.observable(true);
     self.ready = ko.observable(data.name === 'local' || Object.keys(data.peers).length > 0);
     if (self.addr !== null && data.peers !== undefined) {
       let pkeys = Object.keys(data.peers);

--- a/continuousprint/static/js/continuousprint_queue.test.js
+++ b/continuousprint/static/js/continuousprint_queue.test.js
@@ -90,7 +90,7 @@ test('setCount', () => {
 describe('batchSelect', () => {
   let v = init(njobs=4);
   v.jobs()[0].sets([]); // job 1 is empty
-  // job 2 is unstarted; no action needed
+  // job 2 (idx 1) is unstarted; no action needed
   v.jobs()[2].sets()[0].count(3); // Job 3 is incomplete, set 5 is incomplete
   v.jobs()[2].sets()[0].completed(1);
   v.jobs()[2].sets()[0].remaining(2);

--- a/continuousprint/static/js/continuousprint_stats.js
+++ b/continuousprint/static/js/continuousprint_stats.js
@@ -1,0 +1,164 @@
+/*
+ * View model for OctoPrint-Print-Queue
+ *
+ * Contributors: Michael New, Scott Martin
+ * License: AGPLv3
+ */
+
+if (typeof ko === "undefined" || ko === null) {
+  ko = require('knockout');
+}
+if (typeof CPSet === "undefined" || CPSet === null) {
+  CPSet = require('./continuousprint_set');
+}
+
+// Computes aggregate statistics of time, filament, counts etc.
+function CPStats(jobs) {
+  var self = this;
+
+  const Stat = {
+    COUNT: 0,
+    TIME: 1,
+    MASS: 2,
+  };
+
+  const DIMENSION = {
+    remaining:0,
+    total:0,
+    count:0,
+    completed:0,
+  };
+
+  self.header = [
+    {legend: 'Total items', title: null},
+    {legend: 'Total time', title: "Uses Octoprint's file analysis estimate; may be inaccurate"},
+    {legend: 'Total mass', title: "Mass is calculated using active spool(s) in SpoolManager"}
+  ];
+
+  self._safeParse = function(v) {
+    v = parseInt(v, 10);
+    return (isNaN(v)) ? 0 : v;
+  };
+
+  self._appendCount = function(r, d) {
+    r[Stat.COUNT].remaining += d.rem;
+    r[Stat.COUNT].total += d.tot;
+    r[Stat.COUNT].count += d.count;
+    r[Stat.COUNT].completed += d.cplt;
+  };
+
+  self._appendTime = function(r, d) {
+    if (d.ept === null || d.ept === undefined) {
+      r[Stat.TIME].error += 1;
+      return;
+    }
+    r[Stat.TIME].remaining += d.rem * d.ept;
+    r[Stat.TIME].total += d.tot * d.ept
+    r[Stat.TIME].count += d.count * d.ept;
+    r[Stat.TIME].completed += d.cplt * d.ept;
+  };
+
+  self._appendMass = function(r, d) {
+    if (d.len === null || d.len === undefined || d.len.length === 0) {
+      r[Stat.MASS].error += 1;
+      return;
+    }
+    let mass = 0;
+    for (let i = 0; i < d.len.length; i++) {
+      mass += d.linmasses[i] * d.len[i];
+    }
+    if (isNaN(mass)) {
+      r[Stat.MASS].error += 1;
+      return;
+    }
+
+    r[Stat.MASS].remaining += rem * mass;
+    r[Stat.MASS].total += tot * mass;
+    r[Stat.MASS].count += count * mass;
+    r[Stat.MASS].completed += cplt * mass;
+  };
+
+  self.values = ko.computed(function() {
+    r = Array(Object.keys(Stat).length);
+    for (let i = 0; i < Object.keys(Stat).length; i++) {
+      r[i] = {...DIMENSION, error:0};
+    }
+    for (let j of jobs()) {
+      let lm = j.getMaterialLinearMasses();
+      for (let qs of j.sets()) {
+        if (!qs.profile_matches()) {
+          continue;
+        }
+        let meta = qs.metadata;
+        let d = {
+          rem: self._safeParse(qs.remaining()),
+          tot: self._safeParse(qs.length_remaining()),
+          count: self._safeParse(qs.count()),
+          cplt: self._safeParse(qs.completed()),
+          ept: meta && meta.estimatedPrintTime,
+          len: meta && meta.filamentLengths,
+          linmasses: lm,
+        };
+        self._appendCount(r, d);
+        self._appendTime(r, d);
+        self._appendMass(r, d);
+      }
+    }
+    return r;
+  });
+
+  self.humanize = function(num, unit="") {
+    // Humanizes numbers by condensing and adding units
+    let v = '';
+    if (num < 1000) {
+      v = (num % 1 === 0) ? num : num.toFixed(1);
+    } else if (num < 100000) {
+      let k = (num/1000);
+      v = ((k % 1 === 0) ? k : k.toFixed(1)) + 'k';
+    }
+    return v + unit;
+  };
+
+  self.humanTime = function(s) {
+    // Humanizes time values; parameter is seconds
+    if (s < 60) {
+      return Math.round(s) + 's';
+    } else if (s < 3600) {
+      return Math.round(s/60) + 'm';
+    } else if (s < 86400) {
+      let h = s/3600;
+      return ((h % 1 === 0) ? h : h.toFixed(1)) + 'h';
+    } else {
+      let d = s/86400;
+      return ((d % 1 === 0) ? d : d.toFixed(1)) + 'd';
+    }
+  };
+
+  self.values_humanized = ko.computed(function() {
+    let r = self.values();
+    console.log("values() returned", r);
+    for (let i=0; i < r.length; i++) {
+      r[i] = { ...self.header[i], ...r[i]};
+    }
+    for (let k of Object.keys(DIMENSION)) {
+      r[Stat.COUNT][k] = self.humanize(r[0][k]);
+      r[Stat.TIME][k] = self.humanTime(r[1][k]);
+      r[Stat.MASS][k] = self.humanize(r[2][k], 'g');
+    }
+    // Assign error texts
+    r[Stat.COUNT].error = '';
+    r[Stat.TIME].error = (r[1].error > 0) ? `${r[1].error} sets missing time estimates` : '';
+    r[Stat.MASS].error = (r[2].error > 0) ? `${r[1].error} errors calculating mass` : '';
+
+    // TODO
+    // Hide mass details if linmasses is empty (implies SpoolManager not set up)
+    //if (linmasses().length === 0) {
+    //  r.splice(2,1);
+    //}
+    return r;
+  });
+}
+
+try {
+  module.exports = CPStats;
+} catch {}

--- a/continuousprint/templates/continuousprint_settings.jinja2
+++ b/continuousprint/templates/continuousprint_settings.jinja2
@@ -10,6 +10,29 @@
   const CP_LOCAL_IP = {{plugin_continuousprint_local_ip|tojson|safe}};
   const CP_EXCEPTIONS = {{plugin_continuousprint_exceptions|tojson|safe}};
   const CP_SIMULATOR_DEFAULT_SYMTABLE = function() {return {{plugin_continuousprint_simulator_default_symtable|tojson|safe}}; };
+
+  const CP_STATS_DIMENSIONS = {
+    completed: {
+      name: "completed",
+      display: "Complete",
+      desc: "Number of prints completed for this iteration of the job",
+    },
+    count: {
+      name: "count",
+      display: "Per Run",
+      desc: "Number of prints per each iteration of the job",
+    },
+    remaining: {
+      name: "remaining",
+      display: "This Run",
+      desc: "Number of prints yet to be printed for the current job iteration",
+    },
+    total: {
+      name: "total",
+      display: "Pending",
+      desc: "Total number of prints yet to be printed across all remaining iterations of the job",
+    },
+  };
 </script>
 
 <ul id="settings_continuousprint_tabs" class="nav nav-pills">

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -92,12 +92,6 @@
   </div>
 
   <div id="continuousprint_tab_queues" class="tab-pane active" data-bind="foreach: {data: queues, as: 'queue'}">
-
-    <div class="stats" data-bind="visible: $root.hasDraftJob">
-      Totals:
-      <div data-bind="text: JSON.stringify(totals().values_humanized())"></div>
-    </div>
-
     <div class="cp-queue" data-bind="css: {'loading': $root.loading() || !ready()}">
     <div class="cp-header action-bar">
         <div class="multiselect">
@@ -186,10 +180,11 @@
               <!-- ko if: draft() -->
                 <div class="edit-header">
                   <div style="flex: 1;" class="has_title" title="Sets are print files, repeated multiple times">Set<sup>?</sup></div>
-                  <div class="completed has_title" title="Number of prints completed for this iteration of the job">Complete<sup>?</sup></div>
-                  <div class="count has_title" title="Number of prints per each iteration of the job">Per Run<sup>?</sup></div>
-                  <div class="remaining has_title" title="Number of prints yet to be printed for the current job iteration">This Run<sup>?</sup></div>
-                  <div class="total has_title" title="Total number of prints yet to be printed across all remaining iterations of the job">Pending<sup>?</sup></div>
+                  <!-- ko foreach: Object.values(CP_STATS_DIMENSIONS) -->
+                  <div data-bind="attr:{title: $data.desc, class: $data.name + ' has_title'}">
+                    <span data-bind="text: $data.display"></span><sup>?</sup>
+                  </div>
+                  <!-- /ko -->
                 </div>
               <!-- /ko -->
               <div id="queue_sets" data-bind="cpsortable: {foreach: sets, as: 'set', options: {handle: '.fa-grip-vertical', onStart: $root.sortStart, onEnd: $root.sortEnd, onMove: $root.sortMove, group: 'sets'}}, css: {'empty': sets().length < 1, 'draft': job.draft, 'highlight': $root.draggingSet() && job.draft() && queue.ready()}" class="sets">
@@ -298,8 +293,31 @@
             </div>
           </div>
         </div>
-      </div>
-    </div>
+
+        <div data-bind="visible: hasDraftJobs()"> <!-- queue totals -->
+          <a style="display: block; text-align: center;" href="#" data-bind="click: showStats(!showStats())">show/hide queue stats</a>
+          <div class="stats" data-bind="visible: showStats">
+            <div class="edit-header">
+              <div style="flex: 1;"></div>
+              <!-- ko foreach: Object.values(CP_STATS_DIMENSIONS) -->
+              <div style="cursor: auto" data-bind="attr:{class: $data.name + ' has_title'}, text: $data.display"></div>
+              <!-- /ko -->
+            </div>
+            <div data-bind="foreach: totals().values_humanized">
+              <div class="job-stats">
+                <div style="flex: 1;" data-bind="attr: {title: title}"><span data-bind="text: legend"></span><sup data-bind="visible: title">?</sup></div>
+                <div class="completed" data-bind="text: completed"></div>
+                <div class="count" data-bind="text: count"></div>
+                <div class="remaining" data-bind="text: remaining"></div>
+                <div class="total" data-bind="text: total"></div>
+                <div class="error" data-bind="visible: error, text=error"></div>
+              </div>
+            </div>
+          </div>
+        </div> <!-- queue totals -->
+
+      </div> <!-- accordion queue-list -->
+    </div> <!-- cp-queue -->
   </div><!-- tab foreach queues -->
   <div class="hint" data-bind="hidden: $root.queues().length > 1">
   Hint: Set up additional queues (including <a href="https://smartin015.github.io/continuousprint/lan-queues" target="_blank">LAN queues</a>) in the plugin settings.

--- a/continuousprint/templates/continuousprint_tab.jinja2
+++ b/continuousprint/templates/continuousprint_tab.jinja2
@@ -93,6 +93,11 @@
 
   <div id="continuousprint_tab_queues" class="tab-pane active" data-bind="foreach: {data: queues, as: 'queue'}">
 
+    <div class="stats" data-bind="visible: $root.hasDraftJob">
+      Totals:
+      <div data-bind="text: JSON.stringify(totals().values_humanized())"></div>
+    </div>
+
     <div class="cp-queue" data-bind="css: {'loading': $root.loading() || !ready()}">
     <div class="cp-header action-bar">
         <div class="multiselect">
@@ -275,7 +280,7 @@
                   </div>
                 </div>
                 </div>
-                <div data-bind="foreach: totals, visible: draft">
+                <div data-bind="foreach: totals().values_humanized, visible: draft">
                   <div class="job-stats">
                     <div style="flex: 1;" data-bind="attr: {title: title}"><span data-bind="text: legend"></span><sup data-bind="visible: title">?</sup></div>
                     <div class="completed" data-bind="text: completed"></div>


### PR DESCRIPTION
#184 

* [x] Migrate stats computation to new JS class and allow passing in a whole queue's worth of jobs
* [x] Refactor stats computation to have separate ko.computed for values vs humanized output
* [x] Fix hiding of mass estimates (check if values are 0)
* [x] Prettify formatting of queue-level totals (and hide by default / allow toggling visibility)
* [x] Verify estimate numbers are correctly generated
* [x] Verify multi-selection still works (was modified due to difference in computing totals)
* [x] Fix tests